### PR TITLE
Add Supabase-auth login screen with guest access

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useMemo, useRef, useState, type CSSProperties } from "react";
+
+import { PostCard, type PostCardTheme } from "../../components/PostCard";
+import { featuredPost, posts } from "../../data/posts";
+
+const accentColor = "#d4afe3";
+const accentHoverColor = "#e3c4f0";
+
+type ThemeConfig = PostCardTheme & {
+  page: string;
+  input: string;
+};
+
+export default function Home() {
+  const [theme, setTheme] = useState<"day" | "night">("night");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState("All");
+  const [isCategoryMenuOpen, setIsCategoryMenuOpen] = useState(false);
+  const searchContainerRef = useRef<HTMLDivElement | null>(null);
+
+  const accentVariables = useMemo(
+    () =>
+      ({
+        "--accent": accentColor,
+        "--accent-hover": accentHoverColor,
+      }) satisfies CSSProperties,
+    [],
+  );
+
+  const categories = useMemo(
+    () => [
+      "All",
+      ...Array.from(
+        new Set(
+          posts
+            .map((post) => post.category)
+            .filter((category): category is string => Boolean(category)),
+        ),
+      ),
+    ],
+    [],
+  );
+
+  const themeStyles = useMemo<ThemeConfig>(
+    () =>
+      theme === "night"
+        ? {
+            page: "bg-[#0b0b0f] text-zinc-100",
+            subtleText: "text-zinc-400",
+            bodyText: "text-zinc-300",
+            surface: "border-white/15 bg-white/5",
+            border: "border-white/10",
+            input:
+              "border-b-white/25 bg-black/30 text-zinc-100 placeholder:text-zinc-500 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0 focus:outline-none",
+            surfaceText: "text-zinc-200",
+          }
+        : {
+            page: "bg-[#fdfbff] text-zinc-900",
+            subtleText: "text-zinc-500",
+            bodyText: "text-zinc-600",
+            surface: "border-zinc-200 bg-white/90",
+            border: "border-zinc-200",
+            input:
+              "border-b-zinc-300 bg-white text-zinc-900 placeholder:text-zinc-400 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0 focus:outline-none",
+            surfaceText: "text-zinc-700",
+          },
+    [theme],
+  );
+
+  const filteredPosts = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+
+    return posts.filter((post) => {
+      const matchesQuery =
+        normalizedQuery.length === 0 ||
+        [post.title, post.excerpt].some((field) => field.toLowerCase().includes(normalizedQuery));
+      const matchesCategory = selectedCategory === "All" || post.category === selectedCategory;
+
+      return matchesQuery && matchesCategory;
+    });
+  }, [searchQuery, selectedCategory]);
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-500 ${themeStyles.page}`}
+      style={accentVariables}
+    >
+      <div className="mx-auto flex max-w-4xl flex-col gap-20 px-6 pb-20 pt-12 sm:px-8 sm:pt-16">
+        <nav className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <span className="barcode-logo text-4xl uppercase" style={{ color: accentColor }}>
+            D. kline
+          </span>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+            <div
+              ref={searchContainerRef}
+              className="relative flex w-full min-w-[14rem] items-center gap-2 sm:w-80 sm:justify-end"
+              onBlur={(event) => {
+                if (
+                  searchContainerRef.current &&
+                  event.relatedTarget instanceof Node &&
+                  searchContainerRef.current.contains(event.relatedTarget)
+                ) {
+                  return;
+                }
+
+                setIsCategoryMenuOpen(false);
+              }}
+            >
+              <label className="sr-only" htmlFor="site-search">
+                Search posts
+              </label>
+              <input
+                id="site-search"
+                type="search"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                onFocus={() => setIsCategoryMenuOpen(true)}
+                onKeyDown={() => setIsCategoryMenuOpen(true)}
+                placeholder="Search notes"
+                className={`h-10 w-full rounded-none border-x-0 border-t-0 border-b-[0.5px] px-3 text-sm tracking-wide transition-colors duration-200 hover:border-[#d4afe3] focus:border-[#d4afe3] ${themeStyles.input}`}
+              />
+              {isCategoryMenuOpen && (
+                <div
+                  role="listbox"
+                  aria-label="Filter posts by category"
+                  className={`absolute left-0 top-full z-20 mt-2 w-full rounded-sm border p-2 shadow-lg backdrop-blur ${themeStyles.surface}`}
+                >
+                  <p className={`mb-2 text-xs uppercase tracking-[0.35em] ${themeStyles.subtleText}`}>Browse categories</p>
+                  <div className="flex flex-wrap gap-2">
+                    {categories.map((category) => {
+                      const isSelected = selectedCategory === category;
+
+                      return (
+                        <button
+                          key={category}
+                          type="button"
+                          role="option"
+                          aria-selected={isSelected}
+                          onClick={() => {
+                            setSelectedCategory(category);
+                            setIsCategoryMenuOpen(false);
+                          }}
+                          className={`rounded-sm border px-3 py-1 text-[0.65rem] font-medium uppercase tracking-[0.3em] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0 ${
+                            isSelected
+                              ? theme === "night"
+                                ? "border-[var(--accent)] text-zinc-100"
+                                : "border-[var(--accent)] text-zinc-800"
+                              : theme === "night"
+                                ? "border-transparent text-zinc-300 hover:border-[var(--accent)] hover:text-zinc-100"
+                                : "border-transparent text-zinc-600 hover:border-[var(--accent)] hover:text-zinc-900"
+                          } cursor-pointer`}
+                          onFocus={() => setIsCategoryMenuOpen(true)}
+                        >
+                          {category}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </nav>
+
+        <header className="space-y-8">
+          <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-2">
+              <span className="text-xs uppercase tracking-[0.5em] opacity-80" style={{ color: accentColor }}>
+                Journal
+              </span>
+              <h1 className="text-4xl font-semibold leading-tight sm:text-5xl">
+                Writing about craft, curiosity, and the slow web.
+              </h1>
+            </div>
+            <button
+              type="button"
+              onClick={() => setTheme((mode) => (mode === "night" ? "day" : "night"))}
+              aria-label="Toggle day and night theme"
+              className={`flex h-10 w-10 items-center justify-center rounded-sm border text-base transition-colors duration-300 cursor-pointer ${
+                theme === "night"
+                  ? "border-white/20 text-zinc-200 hover:border-[#d4afe3] hover:bg-[rgba(212,175,227,0.18)] hover:text-[#d4afe3]"
+                  : "border-zinc-300 text-zinc-600 hover:border-[#d4afe3] hover:bg-[rgba(212,175,227,0.2)] hover:text-[#d4afe3]"
+              }`}
+            >
+              <span aria-hidden>{theme === "night" ? "☾" : "☀"}</span>
+            </button>
+          </div>
+          <p className={`max-w-2xl text-base sm:text-lg ${themeStyles.bodyText}`}>
+            I'm documenting the experiments that make my creative work feel more intentional—design systems that
+            breathe, the stacks that keep me curious, and the habits that tether ideas to everyday life.
+          </p>
+        </header>
+
+        <section className="space-y-4">
+          <p className="text-xs uppercase tracking-[0.35em] opacity-80" style={{ color: accentColor }}>
+            Featured
+          </p>
+          <PostCard post={featuredPost} theme={theme} themeStyles={themeStyles} variant="featured" />
+        </section>
+
+        <section className="space-y-8">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h2 className="text-xs uppercase tracking-[0.45em]" style={{ color: accentColor }}>
+              Recent posts
+            </h2>
+            <a
+              className="text-sm font-medium transition-colors duration-200"
+              style={{ color: accentColor }}
+              href="#archive"
+            >
+              View archive →
+            </a>
+          </div>
+          <div className="space-y-6">
+            {filteredPosts.map((post) => (
+              <PostCard key={post.title} post={post} theme={theme} themeStyles={themeStyles} />
+            ))}
+            {filteredPosts.length === 0 && (
+              <p className={`text-sm ${themeStyles.subtleText}`}>
+                No posts found. Try adjusting your search or selecting a different filter.
+              </p>
+            )}
+          </div>
+        </section>
+
+        <footer className={`rounded-md border p-8 text-sm transition-colors duration-300 ${themeStyles.surface}`}>
+          <p className={themeStyles.bodyText}>
+            Want notes in your inbox? Join the monthly dispatch and get the behind-the-scenes experiments before they
+            ship.
+          </p>
+          <form className="mt-6 flex flex-col gap-3 sm:flex-row">
+            <input
+              className={`h-11 flex-1 rounded-sm px-4 text-sm transition-colors duration-200 ${themeStyles.input}`}
+              type="email"
+              name="email"
+              placeholder="you@example.com"
+              aria-label="Email address"
+            />
+            <button
+              className="h-11 rounded-sm bg-[var(--accent)] px-6 text-sm font-semibold text-[#1f0b2a] transition-colors duration-300 hover:bg-[var(--accent-hover)] cursor-pointer"
+              type="submit"
+            >
+              Subscribe
+            </button>
+          </form>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,251 +1,271 @@
 "use client";
 
-import { useMemo, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
 
-import { PostCard, type PostCardTheme } from "../components/PostCard";
-import { featuredPost, posts } from "../data/posts";
+import {
+  isSupabaseConfigured,
+  signInWithPassword,
+  signUpWithPassword,
+  type SupabaseSession,
+  upsertProfile,
+} from "../lib/supabase";
 
-const accentColor = "#d4afe3";
-const accentHoverColor = "#e3c4f0";
+type AuthMode = "signin" | "signup";
 
-type ThemeConfig = PostCardTheme & {
-  page: string;
-  input: string;
+type FormState = {
+  email: string;
+  password: string;
+  confirmPassword: string;
 };
 
-export default function Home() {
-  const [theme, setTheme] = useState<"day" | "night">("night");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState("All");
-  const [isCategoryMenuOpen, setIsCategoryMenuOpen] = useState(false);
-  const searchContainerRef = useRef<HTMLDivElement | null>(null);
+const accentColor = "#d4afe3";
 
-  const accentVariables = useMemo(
-    () =>
-      ({
-        "--accent": accentColor,
-        "--accent-hover": accentHoverColor,
-      }) satisfies CSSProperties,
-    [],
-  );
+function persistSession(session: SupabaseSession) {
+  if (typeof window === "undefined") {
+    return;
+  }
 
-  const categories = useMemo(
-    () => [
-      "All",
-      ...Array.from(
-        new Set(
-          posts
-            .map((post) => post.category)
-            .filter((category): category is string => Boolean(category)),
-        ),
-      ),
-    ],
-    [],
-  );
+  window.localStorage.setItem("sb-access-token", session.access_token);
+  window.localStorage.setItem("sb-refresh-token", session.refresh_token);
+  window.localStorage.setItem("sb-user-id", session.user.id);
+  if (session.user.email) {
+    window.localStorage.setItem("sb-user-email", session.user.email);
+  }
+}
 
-  const themeStyles = useMemo<ThemeConfig>(
-    () =>
-      theme === "night"
-        ? {
-            page: "bg-[#0b0b0f] text-zinc-100",
-            subtleText: "text-zinc-400",
-            bodyText: "text-zinc-300",
-            surface: "border-white/15 bg-white/5",
-            border: "border-white/10",
-            input:
-              "border-b-white/25 bg-black/30 text-zinc-100 placeholder:text-zinc-500 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0 focus:outline-none",
-            surfaceText: "text-zinc-200",
-          }
-        : {
-            page: "bg-[#fdfbff] text-zinc-900",
-            subtleText: "text-zinc-500",
-            bodyText: "text-zinc-600",
-            surface: "border-zinc-200 bg-white/90",
-            border: "border-zinc-200",
-            input:
-              "border-b-zinc-300 bg-white text-zinc-900 placeholder:text-zinc-400 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0 focus:outline-none",
-            surfaceText: "text-zinc-700",
-          },
-    [theme],
-  );
+function resetSessionStorage() {
+  if (typeof window === "undefined") {
+    return;
+  }
 
-  const filteredPosts = useMemo(() => {
-    const normalizedQuery = searchQuery.trim().toLowerCase();
+  window.localStorage.removeItem("sb-access-token");
+  window.localStorage.removeItem("sb-refresh-token");
+  window.localStorage.removeItem("sb-user-id");
+  window.localStorage.removeItem("sb-user-email");
+}
 
-    return posts.filter((post) => {
-      const matchesQuery =
-        normalizedQuery.length === 0 ||
-        [post.title, post.excerpt].some((field) => field.toLowerCase().includes(normalizedQuery));
-      const matchesCategory = selectedCategory === "All" || post.category === selectedCategory;
+export default function AuthGateway() {
+  const router = useRouter();
+  const [mode, setMode] = useState<AuthMode>("signin");
+  const [form, setForm] = useState<FormState>({ email: "", password: "", confirmPassword: "" });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
 
-      return matchesQuery && matchesCategory;
-    });
-  }, [searchQuery, selectedCategory]);
+  const supabaseReady = useMemo(() => isSupabaseConfigured(), []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const existingToken = window.localStorage.getItem("sb-access-token");
+    if (existingToken) {
+      router.replace("/home");
+    }
+  }, [router]);
+
+  const updateField = (field: keyof FormState) => (event: ChangeEvent<HTMLInputElement>) => {
+    setForm((current) => ({ ...current, [field]: event.target.value }));
+  };
+
+  const toggleMode = () => {
+    setMode((current) => (current === "signin" ? "signup" : "signin"));
+    setError(null);
+    setInfo(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setInfo(null);
+
+    if (!supabaseReady) {
+      setError("Supabase credentials are not configured. Update your environment variables and try again.");
+      return;
+    }
+
+    if (mode === "signup" && form.password !== form.confirmPassword) {
+      setError("Passwords do not match. Please confirm your password.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      if (mode === "signin") {
+        const session = await signInWithPassword(form.email, form.password);
+        persistSession(session);
+        router.replace("/home");
+        return;
+      }
+
+      const { session, user, requiresEmailConfirmation } = await signUpWithPassword(form.email, form.password);
+
+      if (requiresEmailConfirmation) {
+        setInfo(
+          "Check your inbox to confirm the sign-up. You'll be able to log in after verifying your email address.",
+        );
+        resetSessionStorage();
+        return;
+      }
+
+      if (!session) {
+        throw new Error("Supabase did not return a session for the new user.");
+      }
+
+      const profileId = session.user.id || user?.id;
+      if (!profileId) {
+        throw new Error("Unable to resolve the new user's identifier.");
+      }
+
+      await upsertProfile(session.access_token, {
+        id: profileId,
+        email: user?.email ?? form.email,
+      });
+
+      persistSession(session);
+      router.replace("/home");
+    } catch (authError) {
+      const message = authError instanceof Error ? authError.message : "Something went wrong. Please try again.";
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleGuestAccess = () => {
+    router.replace("/home");
+  };
 
   return (
-    <div
-      className={`min-h-screen transition-colors duration-500 ${themeStyles.page}`}
-      style={accentVariables}
-    >
-      <div className="mx-auto flex max-w-4xl flex-col gap-20 px-6 pb-20 pt-12 sm:px-8 sm:pt-16">
-        <nav className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <span className="barcode-logo text-4xl uppercase" style={{ color: accentColor }}>
-            D. kline
-          </span>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
-            <div
-              ref={searchContainerRef}
-              className="relative flex w-full min-w-[14rem] items-center gap-2 sm:w-80 sm:justify-end"
-              onBlur={(event) => {
-                if (
-                  searchContainerRef.current &&
-                  event.relatedTarget instanceof Node &&
-                  searchContainerRef.current.contains(event.relatedTarget)
-                ) {
-                  return;
-                }
+    <div className="relative flex min-h-screen items-center justify-center bg-[#07070c] px-6 py-12 text-zinc-100">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(212,175,227,0.18),_rgba(7,7,12,0.95))]" />
+      <div className="relative w-full max-w-md overflow-hidden rounded-3xl border border-white/10 bg-black/60 shadow-2xl backdrop-blur">
+        <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-transparent via-[var(--accent,_#d4afe3)] to-transparent" />
+        <div className="space-y-8 px-10 pb-12 pt-14">
+          <div className="space-y-3 text-center">
+            <p className="barcode-logo text-4xl uppercase tracking-widest" style={{ color: accentColor }}>
+              D. kline
+            </p>
+            <h1 className="text-2xl font-semibold">Welcome back</h1>
+            <p className="text-sm text-zinc-400">
+              Sign in to pick up where you left off, create a new account, or continue as a guest to explore the journal.
+            </p>
+          </div>
 
-                setIsCategoryMenuOpen(false);
-              }}
-            >
-              <label className="sr-only" htmlFor="site-search">
-                Search posts
+          {!supabaseReady && (
+            <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-sm text-yellow-200">
+              Supabase keys are missing. Provide NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to enable
+              authentication.
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">{error}</div>
+          )}
+
+          {info && (
+            <div className="rounded-lg border border-[var(--accent,_#d4afe3)]/40 bg-[var(--accent,_#d4afe3)]/10 p-3 text-sm text-zinc-100">
+              {info}
+            </div>
+          )}
+
+          <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+            <div className="space-y-2">
+              <label className="text-xs uppercase tracking-[0.4em] text-zinc-400" htmlFor="email">
+                Email
               </label>
               <input
-                id="site-search"
-                type="search"
-                value={searchQuery}
-                onChange={(event) => setSearchQuery(event.target.value)}
-                onFocus={() => setIsCategoryMenuOpen(true)}
-                onKeyDown={() => setIsCategoryMenuOpen(true)}
-                placeholder="Search notes"
-                className={`h-10 w-full rounded-none border-x-0 border-t-0 border-b-[0.5px] px-3 text-sm tracking-wide transition-colors duration-200 hover:border-[#d4afe3] focus:border-[#d4afe3] ${themeStyles.input}`}
+                id="email"
+                type="email"
+                required
+                value={form.email}
+                onChange={updateField("email")}
+                className="h-12 w-full rounded-md border border-white/10 bg-black/40 px-4 text-sm text-zinc-100 outline-none transition focus:border-[var(--accent,_#d4afe3)] focus:ring-2 focus:ring-[var(--accent,_#d4afe3)]/30"
+                placeholder="you@example.com"
+                autoComplete="email"
               />
-              {isCategoryMenuOpen && (
-                <div
-                  role="listbox"
-                  aria-label="Filter posts by category"
-                  className={`absolute left-0 top-full z-20 mt-2 w-full rounded-sm border p-2 shadow-lg backdrop-blur ${themeStyles.surface}`}
-                >
-                  <p className={`mb-2 text-xs uppercase tracking-[0.35em] ${themeStyles.subtleText}`}>Browse categories</p>
-                  <div className="flex flex-wrap gap-2">
-                    {categories.map((category) => {
-                      const isSelected = selectedCategory === category;
-
-                      return (
-                        <button
-                          key={category}
-                          type="button"
-                          role="option"
-                          aria-selected={isSelected}
-                          onClick={() => {
-                            setSelectedCategory(category);
-                            setIsCategoryMenuOpen(false);
-                          }}
-                          className={`rounded-sm border px-3 py-1 text-[0.65rem] font-medium uppercase tracking-[0.3em] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0 ${
-                            isSelected
-                              ? theme === "night"
-                                ? "border-[var(--accent)] text-zinc-100"
-                                : "border-[var(--accent)] text-zinc-800"
-                              : theme === "night"
-                                ? "border-transparent text-zinc-300 hover:border-[var(--accent)] hover:text-zinc-100"
-                                : "border-transparent text-zinc-600 hover:border-[var(--accent)] hover:text-zinc-900"
-                          } cursor-pointer`}
-                          onFocus={() => setIsCategoryMenuOpen(true)}
-                        >
-                          {category}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
             </div>
-          </div>
-        </nav>
 
-        <header className="space-y-8">
-          <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
             <div className="space-y-2">
-              <span className="text-xs uppercase tracking-[0.5em] opacity-80" style={{ color: accentColor }}>
-                Journal
-              </span>
-              <h1 className="text-4xl font-semibold leading-tight sm:text-5xl">
-                Writing about craft, curiosity, and the slow web.
-              </h1>
+              <label className="text-xs uppercase tracking-[0.4em] text-zinc-400" htmlFor="password">
+                Password
+              </label>
+              <input
+                id="password"
+                type="password"
+                required
+                value={form.password}
+                onChange={updateField("password")}
+                className="h-12 w-full rounded-md border border-white/10 bg-black/40 px-4 text-sm text-zinc-100 outline-none transition focus:border-[var(--accent,_#d4afe3)] focus:ring-2 focus:ring-[var(--accent,_#d4afe3)]/30"
+                placeholder="••••••••"
+                autoComplete={mode === "signin" ? "current-password" : "new-password"}
+                minLength={6}
+              />
+            </div>
+
+            {mode === "signup" && (
+              <div className="space-y-2">
+                <label className="text-xs uppercase tracking-[0.4em] text-zinc-400" htmlFor="confirmPassword">
+                  Confirm password
+                </label>
+                <input
+                  id="confirmPassword"
+                  type="password"
+                  required
+                  value={form.confirmPassword}
+                  onChange={updateField("confirmPassword")}
+                  className="h-12 w-full rounded-md border border-white/10 bg-black/40 px-4 text-sm text-zinc-100 outline-none transition focus:border-[var(--accent,_#d4afe3)] focus:ring-2 focus:ring-[var(--accent,_#d4afe3)]/30"
+                  placeholder="Repeat your password"
+                  autoComplete="new-password"
+                  minLength={6}
+                />
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="group flex h-12 w-full items-center justify-center gap-2 rounded-md bg-[var(--accent,_#d4afe3)] px-4 text-sm font-semibold text-[#1f0b2a] transition hover:bg-[#e3c4f0] disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {isSubmitting && (
+              <span
+                aria-hidden
+                className="inline-flex h-4 w-4 animate-spin rounded-full border-2 border-[#1f0b2a]/30 border-r-transparent"
+              />
+            )}
+              {mode === "signin" ? "Sign in" : "Create account"}
+            </button>
+          </form>
+
+          <div className="flex items-center justify-between text-sm text-zinc-400">
+            <span>{mode === "signin" ? "Need an account?" : "Already have an account?"}</span>
+            <button
+              type="button"
+              onClick={toggleMode}
+              className="font-medium text-[var(--accent,_#d4afe3)] transition hover:text-white"
+            >
+              {mode === "signin" ? "Sign up" : "Sign in"}
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            <div className="flex items-center gap-3 text-xs uppercase tracking-[0.35em] text-zinc-500">
+              <span className="h-px flex-1 bg-white/10" />
+              <span>or</span>
+              <span className="h-px flex-1 bg-white/10" />
             </div>
             <button
               type="button"
-              onClick={() => setTheme((mode) => (mode === "night" ? "day" : "night"))}
-              aria-label="Toggle day and night theme"
-              className={`flex h-10 w-10 items-center justify-center rounded-sm border text-base transition-colors duration-300 cursor-pointer ${
-                theme === "night"
-                  ? "border-white/20 text-zinc-200 hover:border-[#d4afe3] hover:bg-[rgba(212,175,227,0.18)] hover:text-[#d4afe3]"
-                  : "border-zinc-300 text-zinc-600 hover:border-[#d4afe3] hover:bg-[rgba(212,175,227,0.2)] hover:text-[#d4afe3]"
-              }`}
+              onClick={handleGuestAccess}
+              className="h-12 w-full rounded-md border border-white/15 bg-transparent text-sm font-medium text-zinc-100 transition hover:border-[var(--accent,_#d4afe3)] hover:text-[var(--accent,_#d4afe3)]"
             >
-              <span aria-hidden>{theme === "night" ? "☾" : "☀"}</span>
+              Continue as guest
             </button>
           </div>
-          <p className={`max-w-2xl text-base sm:text-lg ${themeStyles.bodyText}`}>
-            I'm documenting the experiments that make my creative work feel more intentional—design systems that
-            breathe, the stacks that keep me curious, and the habits that tether ideas to everyday life.
-          </p>
-        </header>
-
-        <section className="space-y-4">
-          <p className="text-xs uppercase tracking-[0.35em] opacity-80" style={{ color: accentColor }}>
-            Featured
-          </p>
-          <PostCard post={featuredPost} theme={theme} themeStyles={themeStyles} variant="featured" />
-        </section>
-
-        <section className="space-y-8">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <h2 className="text-xs uppercase tracking-[0.45em]" style={{ color: accentColor }}>
-              Recent posts
-            </h2>
-            <a
-              className="text-sm font-medium transition-colors duration-200"
-              style={{ color: accentColor }}
-              href="#archive"
-            >
-              View archive →
-            </a>
-          </div>
-          <div className="space-y-6">
-            {filteredPosts.map((post) => (
-              <PostCard key={post.title} post={post} theme={theme} themeStyles={themeStyles} />
-            ))}
-            {filteredPosts.length === 0 && (
-              <p className={`text-sm ${themeStyles.subtleText}`}>
-                No posts found. Try adjusting your search or selecting a different filter.
-              </p>
-            )}
-          </div>
-        </section>
-
-        <footer className={`rounded-md border p-8 text-sm transition-colors duration-300 ${themeStyles.surface}`}>
-          <p className={themeStyles.bodyText}>
-            Want notes in your inbox? Join the monthly dispatch and get the behind-the-scenes experiments before they
-            ship.
-          </p>
-          <form className="mt-6 flex flex-col gap-3 sm:flex-row">
-            <input
-              className={`h-11 flex-1 rounded-sm px-4 text-sm transition-colors duration-200 ${themeStyles.input}`}
-              type="email"
-              name="email"
-              placeholder="you@example.com"
-              aria-label="Email address"
-            />
-            <button
-              className="h-11 rounded-sm bg-[var(--accent)] px-6 text-sm font-semibold text-[#1f0b2a] transition-colors duration-300 hover:bg-[var(--accent-hover)] cursor-pointer"
-              type="submit"
-            >
-              Subscribe
-            </button>
-          </form>
-        </footer>
+        </div>
       </div>
     </div>
   );

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -1,5 +1,30 @@
 import type { Post } from "../data/posts";
-import { Bookmark, BookmarkCheck } from "lucide-react";
+
+const BookmarkIcon = ({
+  filled = false,
+  className = "",
+}: {
+  filled?: boolean;
+  className?: string;
+}) => (
+  <svg
+    aria-hidden
+    className={className}
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path
+      d="M6 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v17l-6-3.5L6 20Z"
+      fill={filled ? "currentColor" : "none"}
+    />
+  </svg>
+);
 
 export type PostCardTheme = {
   subtleText: string;
@@ -15,11 +40,6 @@ type PostCardProps = {
   themeStyles: PostCardTheme;
   variant?: "default" | "featured";
 };
-
-const accentHoverBackground = {
-  day: "hover:bg-[rgba(212,175,227,0.18)]",
-  night: "hover:bg-[rgba(212,175,227,0.12)]",
-} as const;
 
 export function PostCard({
   post,
@@ -108,7 +128,7 @@ export function PostCard({
               : `text-zinc-600 hover:border-[var(--accent)] hover:text-yellow-300`
           }`}
         >
-          <Bookmark aria-hidden />
+          <BookmarkIcon />
         </button>
       </div>
     </article>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,182 @@
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export type SupabaseSession = {
+  access_token: string;
+  refresh_token: string;
+  user: {
+    id: string;
+    email?: string | null;
+  };
+};
+
+export type SupabaseUser = SupabaseSession["user"];
+
+type SupabaseAuthResponse = {
+  access_token?: string;
+  refresh_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  user?: SupabaseUser;
+  session?: {
+    access_token: string;
+    refresh_token: string;
+    user?: SupabaseUser;
+  } | null;
+};
+
+type SupabaseErrorPayload = {
+  error_description?: string;
+  message?: string;
+  error?: string;
+};
+
+function requireConfig() {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    throw new Error(
+      "Supabase environment variables are missing. Make sure NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are set.",
+    );
+  }
+
+  return {
+    url: SUPABASE_URL.replace(/\/$/, ""),
+    anonKey: SUPABASE_ANON_KEY,
+  } as const;
+}
+
+async function parseJsonSafe<T>(response: Response): Promise<T | null> {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch (error) {
+    console.warn("Failed to parse Supabase response", error);
+    return null;
+  }
+}
+
+function buildHeaders(headers?: HeadersInit) {
+  const { anonKey } = requireConfig();
+  const baseHeaders: Record<string, string> = {
+    apikey: anonKey,
+  };
+
+  if (headers) {
+    return {
+      ...baseHeaders,
+      ...(headers as Record<string, string>),
+    } satisfies HeadersInit;
+  }
+
+  return baseHeaders satisfies HeadersInit;
+}
+
+async function supabaseRequest<T>(path: string, init: RequestInit): Promise<T> {
+  const { url } = requireConfig();
+  const response = await fetch(`${url}${path}`, {
+    ...init,
+    headers: buildHeaders(init.headers),
+  });
+
+  const data = await parseJsonSafe<T | SupabaseErrorPayload>(response);
+
+  if (!response.ok) {
+    const errorPayload = data as SupabaseErrorPayload | null;
+    const message =
+      errorPayload?.error_description || errorPayload?.message || errorPayload?.error || response.statusText;
+    throw new Error(message || "Unexpected error communicating with Supabase.");
+  }
+
+  return (data as T | null) ?? ({} as T);
+}
+
+function mapAuthResponse(payload: SupabaseAuthResponse): SupabaseSession {
+  const session = payload.session;
+  if (session?.access_token && session.refresh_token) {
+    return {
+      access_token: session.access_token,
+      refresh_token: session.refresh_token,
+      user: session.user ?? payload.user ?? { id: "" },
+    };
+  }
+
+  if (payload.access_token && payload.refresh_token) {
+    return {
+      access_token: payload.access_token,
+      refresh_token: payload.refresh_token,
+      user: payload.user ?? { id: "" },
+    };
+  }
+
+  throw new Error("Supabase did not return a session. Check your authentication settings.");
+}
+
+export function isSupabaseConfigured() {
+  return Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
+}
+
+export async function signInWithPassword(email: string, password: string): Promise<SupabaseSession> {
+  const payload = await supabaseRequest<SupabaseAuthResponse>(`/auth/v1/token?grant_type=password`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email, password }),
+  });
+
+  return mapAuthResponse(payload);
+}
+
+export async function signUpWithPassword(email: string, password: string): Promise<{
+  session: SupabaseSession | null;
+  user: SupabaseUser | null;
+  requiresEmailConfirmation: boolean;
+}> {
+  const payload = await supabaseRequest<SupabaseAuthResponse>(`/auth/v1/signup`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email, password }),
+  });
+
+  const session = (() => {
+    try {
+      return mapAuthResponse(payload);
+    } catch (error) {
+      return null;
+    }
+  })();
+
+  return {
+    session,
+    user: payload.user ?? session?.user ?? null,
+    requiresEmailConfirmation: !session,
+  };
+}
+
+export async function upsertProfile(
+  accessToken: string,
+  profile: Record<string, unknown> & { id: string },
+): Promise<void> {
+  const { url } = requireConfig();
+  const response = await fetch(`${url}/rest/v1/profiles`, {
+    method: "POST",
+    headers: buildHeaders({
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      Prefer: "resolution=merge-duplicates",
+    }),
+    body: JSON.stringify(profile),
+  });
+
+  if (!response.ok) {
+    const errorPayload = await parseJsonSafe<SupabaseErrorPayload>(response);
+    const message =
+      errorPayload?.error_description || errorPayload?.message || errorPayload?.error || response.statusText;
+    throw new Error(message || "Unable to create profile record.");
+  }
+}


### PR DESCRIPTION
## Summary
- replace the landing page with an authentication gateway that supports Supabase email login, sign-up, and guest access
- add a lightweight Supabase REST helper that signs in users, provisions profiles, and handles missing configuration gracefully
- relocate the original blog index to /home and remove the lucide-react icon dependency with an inline bookmark glyph

## Testing
- npm run build *(fails: blocked from fetching Google Font in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d712cae84c8320ab16ff604e08a229