### PR TITLE
Rebuild auth screen with minimalist day/night shell

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 
+import { AuthForm, type AuthMode } from "../components/auth/AuthForm";
+import { AuthShell, type AuthTheme } from "../components/auth/AuthShell";
 import {
   isSupabaseConfigured,
   signInWithPassword,
@@ -10,8 +12,6 @@ import {
   type SupabaseSession,
   upsertProfile,
 } from "../lib/supabase";
-
-type AuthMode = "signin" | "signup";
 
 type FormState = {
   email: string;
@@ -48,12 +48,20 @@ function resetSessionStorage() {
 export default function AuthGateway() {
   const router = useRouter();
   const [mode, setMode] = useState<AuthMode>("signin");
+  const [theme, setTheme] = useState<AuthTheme>("night");
   const [form, setForm] = useState<FormState>({ email: "", password: "", confirmPassword: "" });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
 
   const supabaseReady = useMemo(() => isSupabaseConfigured(), []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+      setTheme(prefersDark.matches ? "night" : "day");
+    }
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -140,133 +148,24 @@ export default function AuthGateway() {
   };
 
   return (
-    <div className="relative flex min-h-screen items-center justify-center bg-[#07070c] px-6 py-12 text-zinc-100">
-      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(212,175,227,0.18),_rgba(7,7,12,0.95))]" />
-      <div className="relative w-full max-w-md overflow-hidden rounded-3xl border border-white/10 bg-black/60 shadow-2xl backdrop-blur">
-        <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-transparent via-[var(--accent,_#d4afe3)] to-transparent" />
-        <div className="space-y-8 px-10 pb-12 pt-14">
-          <div className="space-y-3 text-center">
-            <p className="barcode-logo text-4xl uppercase tracking-widest" style={{ color: accentColor }}>
-              D. kline
-            </p>
-            <h1 className="text-2xl font-semibold">Welcome back</h1>
-            <p className="text-sm text-zinc-400">
-              Sign in to pick up where you left off, create a new account, or continue as a guest to explore the journal.
-            </p>
-          </div>
-
-          {!supabaseReady && (
-            <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-sm text-yellow-200">
-              Supabase keys are missing. Provide NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to enable
-              authentication.
-            </div>
-          )}
-
-          {error && (
-            <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">{error}</div>
-          )}
-
-          {info && (
-            <div className="rounded-lg border border-[var(--accent,_#d4afe3)]/40 bg-[var(--accent,_#d4afe3)]/10 p-3 text-sm text-zinc-100">
-              {info}
-            </div>
-          )}
-
-          <form className="space-y-4" onSubmit={handleSubmit} noValidate>
-            <div className="space-y-2">
-              <label className="text-xs uppercase tracking-[0.4em] text-zinc-400" htmlFor="email">
-                Email
-              </label>
-              <input
-                id="email"
-                type="email"
-                required
-                value={form.email}
-                onChange={updateField("email")}
-                className="h-12 w-full rounded-md border border-white/10 bg-black/40 px-4 text-sm text-zinc-100 outline-none transition focus:border-[var(--accent,_#d4afe3)] focus:ring-2 focus:ring-[var(--accent,_#d4afe3)]/30"
-                placeholder="you@example.com"
-                autoComplete="email"
-              />
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-xs uppercase tracking-[0.4em] text-zinc-400" htmlFor="password">
-                Password
-              </label>
-              <input
-                id="password"
-                type="password"
-                required
-                value={form.password}
-                onChange={updateField("password")}
-                className="h-12 w-full rounded-md border border-white/10 bg-black/40 px-4 text-sm text-zinc-100 outline-none transition focus:border-[var(--accent,_#d4afe3)] focus:ring-2 focus:ring-[var(--accent,_#d4afe3)]/30"
-                placeholder="••••••••"
-                autoComplete={mode === "signin" ? "current-password" : "new-password"}
-                minLength={6}
-              />
-            </div>
-
-            {mode === "signup" && (
-              <div className="space-y-2">
-                <label className="text-xs uppercase tracking-[0.4em] text-zinc-400" htmlFor="confirmPassword">
-                  Confirm password
-                </label>
-                <input
-                  id="confirmPassword"
-                  type="password"
-                  required
-                  value={form.confirmPassword}
-                  onChange={updateField("confirmPassword")}
-                  className="h-12 w-full rounded-md border border-white/10 bg-black/40 px-4 text-sm text-zinc-100 outline-none transition focus:border-[var(--accent,_#d4afe3)] focus:ring-2 focus:ring-[var(--accent,_#d4afe3)]/30"
-                  placeholder="Repeat your password"
-                  autoComplete="new-password"
-                  minLength={6}
-                />
-              </div>
-            )}
-
-            <button
-              type="submit"
-              disabled={isSubmitting}
-              className="group flex h-12 w-full items-center justify-center gap-2 rounded-md bg-[var(--accent,_#d4afe3)] px-4 text-sm font-semibold text-[#1f0b2a] transition hover:bg-[#e3c4f0] disabled:cursor-not-allowed disabled:opacity-70"
-            >
-              {isSubmitting && (
-              <span
-                aria-hidden
-                className="inline-flex h-4 w-4 animate-spin rounded-full border-2 border-[#1f0b2a]/30 border-r-transparent"
-              />
-            )}
-              {mode === "signin" ? "Sign in" : "Create account"}
-            </button>
-          </form>
-
-          <div className="flex items-center justify-between text-sm text-zinc-400">
-            <span>{mode === "signin" ? "Need an account?" : "Already have an account?"}</span>
-            <button
-              type="button"
-              onClick={toggleMode}
-              className="font-medium text-[var(--accent,_#d4afe3)] transition hover:text-white"
-            >
-              {mode === "signin" ? "Sign up" : "Sign in"}
-            </button>
-          </div>
-
-          <div className="space-y-4">
-            <div className="flex items-center gap-3 text-xs uppercase tracking-[0.35em] text-zinc-500">
-              <span className="h-px flex-1 bg-white/10" />
-              <span>or</span>
-              <span className="h-px flex-1 bg-white/10" />
-            </div>
-            <button
-              type="button"
-              onClick={handleGuestAccess}
-              className="h-12 w-full rounded-md border border-white/15 bg-transparent text-sm font-medium text-zinc-100 transition hover:border-[var(--accent,_#d4afe3)] hover:text-[var(--accent,_#d4afe3)]"
-            >
-              Continue as guest
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+    <AuthShell
+      accentColor={accentColor}
+      theme={theme}
+      onToggleTheme={() => setTheme((current) => (current === "night" ? "day" : "night"))}
+    >
+      <AuthForm
+        mode={mode}
+        theme={theme}
+        form={form}
+        isSubmitting={isSubmitting}
+        supabaseReady={supabaseReady}
+        error={error}
+        info={info}
+        onFieldChange={updateField}
+        onSubmit={handleSubmit}
+        onToggleMode={toggleMode}
+        onGuestAccess={handleGuestAccess}
+      />
+    </AuthShell>
   );
 }

--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -1,0 +1,175 @@
+import type { ChangeEvent, FormEvent } from "react";
+
+import type { AuthTheme } from "./AuthShell";
+
+export type AuthMode = "signin" | "signup";
+
+type FormState = {
+  readonly email: string;
+  readonly password: string;
+  readonly confirmPassword: string;
+};
+
+type AuthFormProps = {
+  readonly mode: AuthMode;
+  readonly theme: AuthTheme;
+  readonly form: FormState;
+  readonly isSubmitting: boolean;
+  readonly supabaseReady: boolean;
+  readonly error: string | null;
+  readonly info: string | null;
+  readonly onFieldChange: (field: keyof FormState) => (event: ChangeEvent<HTMLInputElement>) => void;
+  readonly onSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void> | void;
+  readonly onToggleMode: () => void;
+  readonly onGuestAccess: () => void;
+};
+
+type ThemeTokens = {
+  readonly field: string;
+  readonly label: string;
+  readonly submit: string;
+  readonly outline: string;
+  readonly ghost: string;
+  readonly supabase: string;
+  readonly error: string;
+  readonly info: string;
+  readonly spinner: string;
+};
+
+const themeTokens: Record<AuthTheme, ThemeTokens> = {
+  night: {
+    field:
+      "border border-white/12 bg-[rgba(10,10,16,0.82)] px-4 py-3 text-sm text-zinc-100 transition focus:border-[var(--accent)] focus:ring-1 focus:ring-[var(--accent)]/40 placeholder:text-zinc-500",
+    label: "text-[10px] uppercase tracking-[0.4em] text-zinc-500",
+    submit:
+      "flex h-11 w-full items-center justify-center gap-2 rounded-sm bg-[var(--accent)] px-4 text-sm font-semibold text-[#120813] transition hover:bg-[#e6d4f0] disabled:cursor-wait disabled:opacity-70",
+    outline:
+      "inline-flex h-11 w-full items-center justify-center rounded-sm border border-white/18 text-[11px] font-medium uppercase tracking-[0.35em] text-zinc-300 transition hover:border-[var(--accent)] hover:text-[var(--accent)]",
+    ghost:
+      "inline-flex h-11 w-full items-center justify-center rounded-sm border border-white/12 text-[11px] font-medium uppercase tracking-[0.35em] text-zinc-400 transition hover:border-[var(--accent)] hover:text-[var(--accent)]",
+    supabase:
+      "rounded-sm border border-amber-400/70 bg-amber-400/10 px-4 py-3 text-[11px] uppercase tracking-[0.3em] text-amber-200",
+    error: "rounded-sm border border-red-500/60 bg-red-500/10 px-4 py-3 text-sm text-red-100",
+    info: "rounded-sm border border-[var(--accent)]/40 bg-[rgba(212,175,227,0.14)] px-4 py-3 text-sm text-zinc-100",
+    spinner: "border-zinc-900/20",
+  },
+  day: {
+    field:
+      "border border-zinc-300 bg-white px-4 py-3 text-sm text-zinc-900 transition focus:border-[var(--accent)] focus:ring-1 focus:ring-[var(--accent)]/30 placeholder:text-zinc-400",
+    label: "text-[10px] uppercase tracking-[0.4em] text-zinc-500",
+    submit:
+      "flex h-11 w-full items-center justify-center gap-2 rounded-sm bg-[var(--accent)] px-4 text-sm font-semibold text-[#1f0b2a] transition hover:bg-[#e7d8f1] disabled:cursor-wait disabled:opacity-70",
+    outline:
+      "inline-flex h-11 w-full items-center justify-center rounded-sm border border-zinc-300 text-[11px] font-medium uppercase tracking-[0.35em] text-zinc-600 transition hover:border-[var(--accent)] hover:text-[var(--accent)]",
+    ghost:
+      "inline-flex h-11 w-full items-center justify-center rounded-sm border border-zinc-400 text-[11px] font-medium uppercase tracking-[0.35em] text-zinc-600 transition hover:border-[var(--accent)] hover:text-[var(--accent)]",
+    supabase:
+      "rounded-sm border border-amber-500/50 bg-amber-500/10 px-4 py-3 text-[11px] uppercase tracking-[0.3em] text-amber-700",
+    error: "rounded-sm border border-red-500/60 bg-red-500/10 px-4 py-3 text-sm text-red-600",
+    info: "rounded-sm border border-[var(--accent)]/40 bg-[rgba(212,175,227,0.12)] px-4 py-3 text-sm text-zinc-700",
+    spinner: "border-zinc-100/40",
+  },
+};
+
+export function AuthForm({
+  mode,
+  theme,
+  form,
+  isSubmitting,
+  supabaseReady,
+  error,
+  info,
+  onFieldChange,
+  onSubmit,
+  onToggleMode,
+  onGuestAccess,
+}: AuthFormProps) {
+  const tokens = themeTokens[theme];
+
+  return (
+    <section className="space-y-6">
+      {!supabaseReady && (
+        <div className={tokens.supabase}>
+          Supply NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to enable auth.
+        </div>
+      )}
+
+      {error && <div className={tokens.error}>{error}</div>}
+
+      {info && <div className={tokens.info}>{info}</div>}
+
+      <form className="space-y-5" onSubmit={onSubmit} noValidate>
+        <div className="space-y-2">
+          <label className={tokens.label} htmlFor="email">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            required
+            value={form.email}
+            onChange={onFieldChange("email")}
+            className={tokens.field}
+            placeholder="you@example.com"
+            autoComplete="email"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className={tokens.label} htmlFor="password">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            required
+            value={form.password}
+            onChange={onFieldChange("password")}
+            className={tokens.field}
+            placeholder="••••••••"
+            autoComplete={mode === "signin" ? "current-password" : "new-password"}
+            minLength={6}
+          />
+        </div>
+
+        {mode === "signup" && (
+          <div className="space-y-2">
+            <label className={tokens.label} htmlFor="confirmPassword">
+              Confirm password
+            </label>
+            <input
+              id="confirmPassword"
+              type="password"
+              required
+              value={form.confirmPassword}
+              onChange={onFieldChange("confirmPassword")}
+              className={tokens.field}
+              placeholder="Repeat your password"
+              autoComplete="new-password"
+              minLength={6}
+            />
+          </div>
+        )}
+
+        <button type="submit" disabled={isSubmitting} className={tokens.submit}>
+          {isSubmitting && (
+            <span
+              aria-hidden
+              className={`inline-flex h-4 w-4 animate-spin rounded-full border-2 ${tokens.spinner} border-r-transparent`}
+            />
+          )}
+          {mode === "signin" ? "Sign in" : "Create account"}
+        </button>
+      </form>
+
+      <div className="space-y-3">
+        <button type="button" onClick={onToggleMode} className={tokens.outline}>
+          {mode === "signin" ? "Create account" : "Use existing"}
+        </button>
+        <button type="button" onClick={onGuestAccess} className={tokens.ghost}>
+          Continue as guest
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/components/auth/AuthShell.tsx
+++ b/components/auth/AuthShell.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { CSSProperties, ReactNode } from "react";
+
+export type AuthTheme = "day" | "night";
+
+export type AuthShellProps = {
+  readonly accentColor?: string;
+  readonly theme: AuthTheme;
+  readonly onToggleTheme: () => void;
+  readonly children: ReactNode;
+};
+
+type ShellTokens = {
+  readonly page: string;
+  readonly panel: string;
+  readonly text: string;
+  readonly subtle: string;
+  readonly toggle: string;
+};
+
+const themeTokens: Record<AuthTheme, ShellTokens> = {
+  night: {
+    page: "bg-[#060608]",
+    panel:
+      "border border-white/12 bg-[rgba(6,6,8,0.65)] shadow-[0_30px_60px_-40px_rgba(0,0,0,0.85)] backdrop-blur",
+    text: "text-zinc-100",
+    subtle: "text-zinc-500",
+    toggle:
+      "border-white/20 text-zinc-300 hover:border-[var(--accent)] hover:bg-[rgba(212,175,227,0.12)] hover:text-[var(--accent)]",
+  },
+  day: {
+    page: "bg-[#f7f5fb]",
+    panel: "border border-zinc-300 bg-white shadow-[0_18px_45px_-35px_rgba(24,16,32,0.65)]",
+    text: "text-zinc-900",
+    subtle: "text-zinc-500",
+    toggle:
+      "border-zinc-300 text-zinc-600 hover:border-[var(--accent)] hover:bg-[rgba(212,175,227,0.16)] hover:text-[var(--accent)]",
+  },
+};
+
+export function AuthShell({
+  accentColor = "#d4afe3",
+  theme,
+  onToggleTheme,
+  children,
+}: AuthShellProps) {
+  const tokens = themeTokens[theme];
+
+  return (
+    <main
+      className={`flex min-h-screen flex-col font-mono transition-colors duration-500 ${tokens.page} ${tokens.text}`}
+      style={{ "--accent": accentColor } as CSSProperties}
+    >
+      <header className="flex items-center justify-between px-8 py-6">
+        <span className="barcode-logo text-2xl uppercase tracking-[0.45em]" style={{ color: accentColor }}>
+          D. kline
+        </span>
+        <button
+          type="button"
+          onClick={onToggleTheme}
+          aria-label="Toggle day and night theme"
+          className={`flex h-10 w-10 items-center justify-center rounded-sm border text-base transition-colors duration-300 ${
+            tokens.toggle
+          }`}
+        >
+          <span aria-hidden>{theme === "night" ? "☀" : "☾"}</span>
+        </button>
+      </header>
+      <div className="flex flex-1 items-center justify-center px-6 pb-16 pt-8 sm:px-8">
+        <div className={`w-full max-w-sm rounded-sm ${tokens.panel} px-6 py-8 sm:px-8`}>
+          <div className={`mb-8 text-xs uppercase tracking-[0.45em] ${tokens.subtle}`}>Access</div>
+          {children}
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- redesign the authentication shell with a system-aware day/night toggle, sharper panels, and brand accent highlights
- restyle the form to a monochrome, minimalist layout with accent-driven focus states and streamlined actions
- wire the gateway page into the new shell/theme flow while keeping the existing Supabase logic untouched

## Testing
- npm run build *(fails: unable to fetch Libre Barcode 39 Text from Google Fonts in this environment; Next.js falls back to default font)*

------
https://chatgpt.com/codex/tasks/task_e_68d71eb72d8c83209a58b47d648e9a3c