### PR TITLE
Improve auth form layout and header spacing

### DIFF
--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -39,7 +39,7 @@ type ThemeTokens = {
 const themeTokens: Record<AuthTheme, ThemeTokens> = {
   night: {
     field:
-      "border border-white/12 bg-[rgba(10,10,16,0.82)] px-4 py-3 text-sm text-zinc-100 transition focus:border-[var(--accent)] focus:ring-1 focus:ring-[var(--accent)]/40 placeholder:text-zinc-500",
+      "w-full border border-white/12 bg-[rgba(10,10,16,0.82)] px-4 py-3 text-sm text-zinc-100 transition focus:border-[var(--accent)] focus:ring-1 focus:ring-[var(--accent)]/40 placeholder:text-zinc-500",
     label: "text-[10px] uppercase tracking-[0.4em] text-zinc-500",
     submit:
       "flex h-11 w-full items-center justify-center gap-2 rounded-sm bg-[var(--accent)] px-4 text-sm font-semibold text-[#120813] transition hover:bg-[#e6d4f0] disabled:cursor-wait disabled:opacity-70",
@@ -55,7 +55,7 @@ const themeTokens: Record<AuthTheme, ThemeTokens> = {
   },
   day: {
     field:
-      "border border-zinc-300 bg-white px-4 py-3 text-sm text-zinc-900 transition focus:border-[var(--accent)] focus:ring-1 focus:ring-[var(--accent)]/30 placeholder:text-zinc-400",
+      "w-full border border-zinc-300 bg-white px-4 py-3 text-sm text-zinc-900 transition focus:border-[var(--accent)] focus:ring-1 focus:ring-[var(--accent)]/30 placeholder:text-zinc-400",
     label: "text-[10px] uppercase tracking-[0.4em] text-zinc-500",
     submit:
       "flex h-11 w-full items-center justify-center gap-2 rounded-sm bg-[var(--accent)] px-4 text-sm font-semibold text-[#1f0b2a] transition hover:bg-[#e7d8f1] disabled:cursor-wait disabled:opacity-70",
@@ -87,7 +87,7 @@ export function AuthForm({
   const tokens = themeTokens[theme];
 
   return (
-    <section className="space-y-6">
+    <section className="space-y-8">
       {!supabaseReady && (
         <div className={tokens.supabase}>
           Supply NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to enable auth.
@@ -98,8 +98,8 @@ export function AuthForm({
 
       {info && <div className={tokens.info}>{info}</div>}
 
-      <form className="space-y-5" onSubmit={onSubmit} noValidate>
-        <div className="space-y-2">
+      <form className="space-y-7" onSubmit={onSubmit} noValidate>
+        <div className="space-y-3">
           <label className={tokens.label} htmlFor="email">
             Email
           </label>
@@ -115,7 +115,7 @@ export function AuthForm({
           />
         </div>
 
-        <div className="space-y-2">
+        <div className="space-y-3">
           <label className={tokens.label} htmlFor="password">
             Password
           </label>
@@ -133,7 +133,7 @@ export function AuthForm({
         </div>
 
         {mode === "signup" && (
-          <div className="space-y-2">
+          <div className="space-y-3">
             <label className={tokens.label} htmlFor="confirmPassword">
               Confirm password
             </label>
@@ -162,7 +162,7 @@ export function AuthForm({
         </button>
       </form>
 
-      <div className="space-y-3">
+      <div className="space-y-4">
         <button type="button" onClick={onToggleMode} className={tokens.outline}>
           {mode === "signin" ? "Create account" : "Use existing"}
         </button>

--- a/components/auth/AuthShell.tsx
+++ b/components/auth/AuthShell.tsx
@@ -52,7 +52,7 @@ export function AuthShell({
       className={`flex min-h-screen flex-col font-mono transition-colors duration-500 ${tokens.page} ${tokens.text}`}
       style={{ "--accent": accentColor } as CSSProperties}
     >
-      <header className="flex items-center justify-between px-8 py-6">
+      <header className="mx-auto mt-10 flex w-full max-w-4xl items-center justify-between px-6 py-3">
         <span className="barcode-logo text-4xl uppercase" style={{ color: accentColor }}>
           D. kline
         </span>
@@ -67,9 +67,8 @@ export function AuthShell({
           <span aria-hidden>{theme === "night" ? "☀" : "☾"}</span>
         </button>
       </header>
-      <div className="flex flex-1 items-center justify-center px-6 pb-16 pt-8 sm:px-8">
-        <div className={`w-full max-w-sm rounded-sm ${tokens.panel} px-6 py-8 sm:px-8`}>
-          <div className={`mb-8 text-xs uppercase tracking-[0.45em] ${tokens.subtle}`}>Access</div>
+      <div className="flex flex-1 items-center justify-center px-6 pb-16 pt-10 sm:px-10">
+        <div className={`w-full max-w-xl rounded-sm ${tokens.panel} px-8 py-10 sm:px-12 lg:max-w-2xl`}>
           {children}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- increase spacing and full-width alignment for fields and actions in the auth forms
- enlarge the auth panel on larger screens and remove the redundant "Access" heading
- reposition and resize the navigation header to sit lower on the page while staying centered

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68d724f0068083208a74ccd044ba0038