### PR TITLE
Seed placeholder profiles on signup and align editor surfaces

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,64 @@ type FormState = {
 
 const accentColor = "#d4afe3";
 
+const placeholderAdjectives = [
+  "curious",
+  "lunar",
+  "quiet",
+  "radiant",
+  "stellar",
+  "velvet",
+  "wild",
+  "woven",
+] as const;
+
+const placeholderNouns = [
+  "artisan",
+  "cartographer",
+  "dreamer",
+  "gardener",
+  "scribe",
+  "sojourner",
+  "storyteller",
+  "tinkerer",
+] as const;
+
+const placeholderFocus = [
+  "slow web experiments",
+  "intentional workflows",
+  "everyday rituals",
+  "curiosity loops",
+  "digital gardens",
+  "quiet design",
+] as const;
+
+function capitalize(word: string) {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+function sample<T>(values: readonly T[]): T {
+  return values[Math.floor(Math.random() * values.length)];
+}
+
+function createPlaceholderProfile(id: string) {
+  const adjective = sample(placeholderAdjectives);
+  const noun = sample(placeholderNouns);
+  const focus = sample(placeholderFocus);
+  const condensedId = id.replace(/-/g, "").slice(0, 6);
+  const randomSuffix = Math.random().toString(36).slice(2, 6);
+  const baseUsername = `${adjective}_${noun}`.toLowerCase();
+  const username = `${baseUsername}_${condensedId}${randomSuffix}`.slice(0, 40);
+  const displayName = `${capitalize(adjective)} ${capitalize(noun)}`;
+  const avatarSeed = `${displayName}-${condensedId}`;
+
+  return {
+    username,
+    display_name: displayName,
+    avatar_url: `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(avatarSeed)}`,
+    bio: `Exploring ${focus} as a ${displayName.toLowerCase()} in progress.`,
+  } as const;
+}
+
 function persistSession(session: SupabaseSession) {
   if (typeof window === "undefined") {
     return;
@@ -128,9 +186,11 @@ export default function AuthGateway() {
         throw new Error("Unable to resolve the new user's identifier.");
       }
 
+      const placeholderProfile = createPlaceholderProfile(profileId);
+
       await upsertProfile(session.access_token, {
         id: profileId,
-        email: user?.email ?? form.email,
+        ...placeholderProfile,
       });
 
       persistSession(session);

--- a/components/editor/EditorShell.module.css
+++ b/components/editor/EditorShell.module.css
@@ -8,7 +8,7 @@
   --editor-muted: rgba(198, 196, 210, 0.66);
   --editor-border: rgba(255, 255, 255, 0.08);
   --editor-subtle-border: rgba(255, 255, 255, 0.05);
-  --editor-surface: rgba(16, 14, 26, 0.72);
+  --editor-surface: rgba(255, 255, 255, 0.05);
   --editor-soft: rgba(255, 255, 255, 0.08);
   --editor-nav-bg: rgba(10, 10, 18, 0.82);
   --editor-sidebar-bg: rgba(7, 7, 12, 0.78);
@@ -16,9 +16,9 @@
   --editor-toolbar-border: rgba(255, 255, 255, 0.08);
   --editor-input-bg: rgba(11, 11, 18, 0.82);
   --editor-input-border: rgba(255, 255, 255, 0.14);
-  --editor-card-bg: rgba(12, 12, 20, 0.82);
+  --editor-card-bg: rgba(255, 255, 255, 0.05);
   --editor-shadow: 0 28px 60px -42px rgba(0, 0, 0, 0.78);
-  --editor-account-bg: rgba(10, 10, 18, 0.88);
+  --editor-account-bg: rgba(255, 255, 255, 0.05);
   background-color: var(--editor-page-bg);
   color: var(--editor-page-text);
 }
@@ -29,7 +29,7 @@
   --editor-muted: rgba(97, 88, 124, 0.76);
   --editor-border: rgba(37, 23, 52, 0.14);
   --editor-subtle-border: rgba(37, 23, 52, 0.08);
-  --editor-surface: rgba(255, 255, 255, 0.94);
+  --editor-surface: rgba(255, 255, 255, 0.9);
   --editor-soft: rgba(238, 231, 248, 0.92);
   --editor-nav-bg: rgba(250, 247, 255, 0.94);
   --editor-sidebar-bg: rgba(247, 244, 255, 0.95);
@@ -37,9 +37,9 @@
   --editor-toolbar-border: rgba(35, 25, 48, 0.15);
   --editor-input-bg: rgba(255, 255, 255, 0.98);
   --editor-input-border: rgba(35, 25, 48, 0.18);
-  --editor-card-bg: rgba(255, 255, 255, 0.97);
+  --editor-card-bg: rgba(255, 255, 255, 0.9);
   --editor-shadow: 0 32px 70px -48px rgba(42, 28, 58, 0.32);
-  --editor-account-bg: rgba(255, 255, 255, 0.96);
+  --editor-account-bg: rgba(255, 255, 255, 0.9);
   background-color: var(--editor-page-bg);
   color: var(--editor-page-text);
 }


### PR DESCRIPTION
## Summary
- generate placeholder usernames, display names, avatars, and bios for new sign-ups before inserting into the `profiles` table
- align the editor shell surface and account panel colors with the home page footer color for both day and night themes

## Testing
- npm run build *(fails: Next.js cannot download Libre Barcode 39 Text in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7d068ae4832093ec96d6785a38f1