### PR TITLE
Refine editor navigation layout

### DIFF
--- a/components/editor/AccountPanel.tsx
+++ b/components/editor/AccountPanel.tsx
@@ -55,47 +55,46 @@ export function AccountPanel() {
     window.location.href = "/";
   };
 
+  const accountName = loading ? "Loading account…" : account?.name || "Guest";
+  const accountEmail = loading ? "" : account?.email ?? "";
+
   return (
     <div className="space-y-4 text-sm text-[color:var(--editor-muted)]">
-      <div className="flex items-center gap-3">
-        <div
-          className="flex h-11 w-11 items-center justify-center rounded-full text-base font-semibold"
+      <div className="flex items-center justify-between gap-3">
+        <Link
+          href="/account"
+          className="group relative flex h-11 w-11 items-center justify-center rounded-full text-base font-semibold transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
           style={{
             backgroundColor: "var(--editor-soft)",
             color: "var(--editor-page-text)",
             boxShadow: "var(--editor-shadow)",
           }}
         >
-          {initials}
-        </div>
-        <div className="min-w-0">
-          <p className="truncate text-sm font-semibold text-[color:var(--editor-page-text)]">
-            {loading ? "Loading account…" : account?.name || "Guest"}
-          </p>
-          {account?.email && <p className="truncate text-xs">{account.email}</p>}
-        </div>
-      </div>
-      <div className="flex flex-col gap-2 text-xs font-medium uppercase tracking-[0.28em] text-[color:var(--editor-muted)]">
-        <Link
-          href="/settings"
-          className="rounded-md border border-[var(--editor-border)] px-3 py-2 text-center transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-        >
-          Settings
+          <span aria-hidden>{initials}</span>
+          <span className="pointer-events-none absolute left-full top-1/2 z-10 ml-3 min-w-[12rem] -translate-y-1/2 rounded-md border border-[var(--editor-border)] bg-[var(--editor-surface)] px-3 py-2 text-left text-xs font-medium text-[color:var(--editor-page-text)] opacity-0 shadow-[var(--editor-shadow)] transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100">
+            <span className="block text-sm font-semibold">{accountName}</span>
+            {accountEmail && <span className="mt-1 block text-[0.7rem] text-[color:var(--editor-muted)]">{accountEmail}</span>}
+          </span>
+          <span className="sr-only">Open account</span>
         </Link>
-        <Link
-          href="/account"
-          className="rounded-md border border-[var(--editor-border)] px-3 py-2 text-center transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-        >
-          Account
-        </Link>
-        <button
-          type="button"
-          onClick={handleSignOut}
-          className="rounded-md border border-[var(--editor-border)] px-3 py-2 text-center transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-          style={{ color: accentColor }}
-        >
-          Sign out
-        </button>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/settings"
+            className="flex h-9 w-9 items-center justify-center rounded-md border border-[var(--editor-border)] text-base transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+          >
+            <span aria-hidden>⚙</span>
+            <span className="sr-only">Open settings</span>
+          </Link>
+          <button
+            type="button"
+            onClick={handleSignOut}
+            className="flex h-9 w-9 items-center justify-center rounded-md border border-[var(--editor-border)] text-base transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            style={{ color: accentColor }}
+          >
+            <span aria-hidden>⎋</span>
+            <span className="sr-only">Sign out</span>
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/components/editor/DraftsSidebar.tsx
+++ b/components/editor/DraftsSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -21,7 +21,237 @@ type DraftEventDetail = {
   readonly slug?: string;
 };
 
+type CustomFileNode = {
+  readonly id: string;
+  readonly name: string;
+  readonly type: "file";
+};
+
+type CustomFolderNode = {
+  readonly id: string;
+  readonly name: string;
+  readonly type: "folder";
+  readonly children: readonly CustomTreeNode[];
+};
+
+type CustomTreeNode = CustomFolderNode | CustomFileNode;
+
+type DraftTreeNode = {
+  readonly id: string;
+  readonly name: string;
+  readonly type: "draft";
+  readonly slug: string;
+  readonly updatedAt: string | null;
+};
+
+type FolderTreeNode = {
+  readonly id: string;
+  readonly name: string;
+  readonly type: "folder";
+  readonly origin: "system" | "custom";
+  readonly children: readonly TreeNode[];
+};
+
+type CustomFileTreeNode = {
+  readonly id: string;
+  readonly name: string;
+  readonly type: "file";
+  readonly origin: "custom";
+};
+
+type MessageTreeNode = {
+  readonly id: string;
+  readonly message: string;
+  readonly type: "message";
+};
+
+type TreeNode = DraftTreeNode | FolderTreeNode | CustomFileTreeNode | MessageTreeNode;
+
+type TreeNodeItemProps = {
+  readonly node: TreeNode;
+  readonly depth: number;
+  readonly accentColor: string;
+  readonly expandedFolders: readonly string[];
+  readonly activeSlug: string | null;
+  readonly onToggle: (folderId: string) => void;
+  readonly onCreateFolder: (parentId: string | null) => void;
+  readonly onCreateFile: (parentId: string | null) => void;
+};
+
 const toTitle = (title: string | null) => (title && title.trim().length > 0 ? title : "Untitled draft");
+
+const createNodeId = (prefix: string) => {
+  const random = globalThis.crypto?.randomUUID?.();
+  if (random) {
+    return `${prefix}-${random}`;
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+const addCustomNode = (
+  nodes: readonly CustomTreeNode[],
+  parentId: string | null,
+  newNode: CustomTreeNode,
+): readonly CustomTreeNode[] => {
+  if (!parentId) {
+    return [...nodes, newNode];
+  }
+
+  return nodes.map((node) => {
+    if (node.type !== "folder") {
+      return node;
+    }
+    if (node.id === parentId) {
+      return { ...node, children: [...node.children, newNode] };
+    }
+    return { ...node, children: addCustomNode(node.children, parentId, newNode) };
+  });
+};
+
+const convertCustomNodes = (nodes: readonly CustomTreeNode[]): readonly TreeNode[] =>
+  nodes.map((node) =>
+    node.type === "folder"
+      ? {
+          id: node.id,
+          name: node.name,
+          type: "folder" as const,
+          origin: "custom" as const,
+          children: convertCustomNodes(node.children),
+        }
+      : { id: node.id, name: node.name, type: "file" as const, origin: "custom" as const },
+  );
+
+const formatUpdatedAt = (updatedAt: string | null) =>
+  updatedAt ? new Date(updatedAt).toLocaleString() : "Never saved";
+
+function TreeNodeItem({
+  node,
+  depth,
+  accentColor,
+  expandedFolders,
+  activeSlug,
+  onToggle,
+  onCreateFolder,
+  onCreateFile,
+}: TreeNodeItemProps) {
+  const indentStyle = { paddingLeft: `${depth * 0.75}rem` };
+
+  if (node.type === "folder") {
+    const isExpanded = expandedFolders.includes(node.id);
+
+    return (
+      <li>
+        <div
+          className="group flex items-center justify-between rounded-md px-2 py-1 text-sm font-medium text-[color:var(--editor-muted)] transition-colors hover:bg-[var(--editor-soft)] hover:text-[color:var(--editor-page-text)]"
+          style={indentStyle}
+        >
+          <button
+            type="button"
+            onClick={() => onToggle(node.id)}
+            className="flex flex-1 items-center gap-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+          >
+            <span aria-hidden className="text-[0.65rem]">
+              {isExpanded ? "▾" : "▸"}
+            </span>
+            <span aria-hidden className="text-base">{node.origin === "system" ? "📂" : "🗂"}</span>
+            <span className="truncate">{node.name}</span>
+          </button>
+          <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onCreateFolder(node.id);
+              }}
+              className="flex h-7 w-7 items-center justify-center rounded border border-[var(--editor-border)] text-[0.7rem] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            >
+              <span aria-hidden>📁+</span>
+              <span className="sr-only">Create folder inside {node.name}</span>
+            </button>
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onCreateFile(node.id);
+              }}
+              className="flex h-7 w-7 items-center justify-center rounded border border-[var(--editor-border)] text-[0.7rem] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            >
+              <span aria-hidden>📄+</span>
+              <span className="sr-only">Create file inside {node.name}</span>
+            </button>
+          </div>
+        </div>
+        {isExpanded && node.children.length > 0 && (
+          <ul className="mt-1 space-y-1">
+            {node.children.map((child) => (
+              <TreeNodeItem
+                key={child.id}
+                node={child}
+                depth={depth + 1}
+                accentColor={accentColor}
+                expandedFolders={expandedFolders}
+                activeSlug={activeSlug}
+                onToggle={onToggle}
+                onCreateFolder={onCreateFolder}
+                onCreateFile={onCreateFile}
+              />
+            ))}
+          </ul>
+        )}
+      </li>
+    );
+  }
+
+  if (node.type === "draft") {
+    const isActive = activeSlug === node.slug;
+
+    return (
+      <li>
+        <Link
+          href={`/write/${node.slug}`}
+          className="group flex items-center gap-2 rounded-md px-2 py-1 text-sm transition-colors hover:bg-[var(--editor-soft)]"
+          style={{
+            ...indentStyle,
+            color: isActive ? accentColor : "var(--editor-page-text)",
+            borderColor: isActive ? accentColor : undefined,
+            backgroundColor: isActive ? "var(--editor-soft)" : undefined,
+          }}
+          title={formatUpdatedAt(node.updatedAt)}
+        >
+          <span aria-hidden className="text-base">📄</span>
+          <span className="truncate group-hover:text-[var(--accent)]" style={isActive ? { color: accentColor } : undefined}>
+            {node.name}
+          </span>
+        </Link>
+      </li>
+    );
+  }
+
+  if (node.type === "file") {
+    return (
+      <li>
+        <div
+          className="flex items-center gap-2 rounded-md px-2 py-1 text-sm text-[color:var(--editor-muted)]"
+          style={indentStyle}
+        >
+          <span aria-hidden className="text-base">📝</span>
+          <span className="truncate">{node.name}</span>
+        </div>
+      </li>
+    );
+  }
+
+  return (
+    <li>
+      <div
+        className="px-2 py-1 text-[0.8rem] text-[color:var(--editor-muted)]"
+        style={indentStyle}
+      >
+        {node.message}
+      </div>
+    </li>
+  );
+}
 
 export default function DraftsSidebar() {
   const supabase = useMemo(() => createClient(), []);
@@ -30,6 +260,8 @@ export default function DraftsSidebar() {
   const [drafts, setDrafts] = useState<readonly DraftSummary[]>([]);
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(true);
+  const [customTree, setCustomTree] = useState<readonly CustomTreeNode[]>([]);
+  const [expandedFolders, setExpandedFolders] = useState<readonly string[]>(["drafts-root"]);
 
   const fetchDrafts = useMemo(
     () =>
@@ -76,11 +308,87 @@ export default function DraftsSidebar() {
     toTitle(draft.title).toLowerCase().includes(query.trim().toLowerCase()),
   );
 
+  const activeSlug = useMemo(() => {
+    if (!pathname) return null;
+    if (!pathname.startsWith("/write/")) return null;
+    const [, slug = null] = pathname.split("/write/");
+    return slug ? slug.split("/")[0] : null;
+  }, [pathname]);
+
+  const workspaceTree = useMemo(() => {
+    const draftChildren: readonly TreeNode[] = loading
+      ? [{ id: "drafts-loading", type: "message", message: "Loading drafts…" }]
+      : filteredDrafts.length > 0
+        ? filteredDrafts.map((draft) => ({
+            id: draft.id,
+            name: toTitle(draft.title),
+            type: "draft" as const,
+            slug: draft.slug,
+            updatedAt: draft.updated_at,
+          }))
+        : [
+            {
+              id: "drafts-empty",
+              type: "message" as const,
+              message: query.trim().length > 0 ? "No drafts match your search." : "No drafts yet. Start something new.",
+            },
+          ];
+
+    const draftsFolder: FolderTreeNode = {
+      id: "drafts-root",
+      name: "Drafts",
+      type: "folder",
+      origin: "system",
+      children: draftChildren,
+    };
+
+    const customNodes = convertCustomNodes(customTree);
+
+    return [draftsFolder, ...customNodes];
+  }, [customTree, filteredDrafts, loading, query]);
+
+  const handleToggleFolder = useCallback((folderId: string) => {
+    setExpandedFolders((prev) =>
+      prev.includes(folderId) ? prev.filter((id) => id !== folderId) : [...prev, folderId],
+    );
+  }, []);
+
+  const handleCreateFolder = useCallback((parentId: string | null) => {
+    const name = window.prompt("Name this folder");
+    const trimmed = name?.trim();
+    if (!trimmed) {
+      return;
+    }
+    const id = createNodeId("folder");
+    setCustomTree((prev) => addCustomNode(prev, parentId, { type: "folder", id, name: trimmed, children: [] }));
+    setExpandedFolders((prev) => {
+      const next = new Set(prev);
+      if (parentId) {
+        next.add(parentId);
+      }
+      next.add(id);
+      return Array.from(next);
+    });
+  }, []);
+
+  const handleCreateFile = useCallback((parentId: string | null) => {
+    const name = window.prompt("Name this file");
+    const trimmed = name?.trim();
+    if (!trimmed) {
+      return;
+    }
+    const id = createNodeId("file");
+    setCustomTree((prev) => addCustomNode(prev, parentId, { type: "file", id, name: trimmed }));
+    if (parentId) {
+      setExpandedFolders((prev) => (prev.includes(parentId) ? prev : [...prev, parentId]));
+    }
+  }, []);
+
   return (
-    <div className="flex h-full flex-col gap-6">
-      <div className="space-y-4 rounded-xl border border-[var(--editor-border)] px-4 py-5 shadow-[var(--editor-shadow)]" style={{ backgroundColor: "var(--editor-surface)" }}>
+    <div className="flex h-full flex-col gap-5">
+      <div className="space-y-3">
         <div className="flex items-center justify-between gap-3">
-          <h2 className="text-xs font-semibold uppercase tracking-[0.4em] text-[color:var(--editor-muted)]">
+          <h2 className="text-xs font-semibold uppercase tracking-[0.35em] text-[color:var(--editor-muted)]">
             Drafts
           </h2>
           <Link
@@ -90,59 +398,62 @@ export default function DraftsSidebar() {
             New
           </Link>
         </div>
-        <label className="block text-[0.7rem] uppercase tracking-[0.3em] text-[color:var(--editor-muted)]">
-          <span className="sr-only">Search drafts</span>
+        <div className="relative">
+          <label className="sr-only" htmlFor="draft-search">
+            Search drafts
+          </label>
           <input
+            id="draft-search"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder="Search drafts"
-            className="mt-2 w-full rounded-md border border-[var(--editor-input-border)] bg-[var(--editor-input-bg)] px-3 py-2 text-[0.8rem] text-[color:var(--editor-page-text)] placeholder:text-[color:var(--editor-muted)] focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-opacity-40"
+            className="w-full border-0 border-b border-[var(--editor-border)] bg-transparent px-1 py-2 text-sm text-[color:var(--editor-page-text)] placeholder:text-[color:var(--editor-muted)] focus:border-[var(--accent)] focus:outline-none focus:ring-0"
             type="search"
           />
-        </label>
+        </div>
       </div>
-      <nav className="flex-1 overflow-y-auto pr-2">
-        <ul className="space-y-2">
-          {loading && (
-            <li className="rounded-lg border border-[var(--editor-border)] bg-[var(--editor-soft)] px-4 py-3 text-xs text-[color:var(--editor-muted)]">
-              Loading drafts…
-            </li>
-          )}
-          {!loading && filteredDrafts.length === 0 && (
-            <li className="rounded-lg border border-[var(--editor-border)] bg-[var(--editor-soft)] px-4 py-3 text-xs text-[color:var(--editor-muted)]">
-              No drafts yet. Start something new.
-            </li>
-          )}
-          {filteredDrafts.map((draft) => {
-            const isActive = pathname?.includes(`/write/${draft.slug}`);
-            const updatedLabel = draft.updated_at
-              ? new Date(draft.updated_at).toLocaleString()
-              : "Never saved";
-            return (
-              <li key={draft.id}>
-                <Link
-                  href={`/write/${draft.slug}`}
-                  className="group block rounded-xl border border-[var(--editor-border)] px-4 py-3 transition-colors hover:border-[var(--accent)]"
-                  style={
-                    isActive
-                      ? {
-                          borderColor: accentColor,
-                          backgroundColor: "var(--editor-soft)",
-                          color: accentColor,
-                        }
-                      : undefined
-                  }
-                >
-                  <p className="truncate text-sm font-semibold text-[color:var(--editor-page-text)] group-hover:text-[var(--accent)]" style={isActive ? { color: accentColor } : undefined}>
-                    {toTitle(draft.title)}
-                  </p>
-                  <p className="mt-1 text-xs text-[color:var(--editor-muted)]">{updatedLabel}</p>
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </nav>
+      <div
+        className="flex flex-1 flex-col overflow-hidden rounded-xl border border-[var(--editor-border)] bg-[var(--editor-surface)] shadow-[var(--editor-shadow)]"
+      >
+        <div className="flex items-center justify-between border-b border-[var(--editor-subtle-border)] px-3 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-[color:var(--editor-muted)]">
+          <span>Workspace</span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => handleCreateFolder(null)}
+              className="flex h-8 w-8 items-center justify-center rounded-md border border-[var(--editor-border)] text-xs transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            >
+              <span aria-hidden>🗂+</span>
+              <span className="sr-only">Create folder</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => handleCreateFile(null)}
+              className="flex h-8 w-8 items-center justify-center rounded-md border border-[var(--editor-border)] text-xs transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            >
+              <span aria-hidden>📄+</span>
+              <span className="sr-only">Create file</span>
+            </button>
+          </div>
+        </div>
+        <nav className="flex-1 overflow-y-auto px-1 py-3">
+          <ul className="space-y-1 text-sm">
+            {workspaceTree.map((node) => (
+              <TreeNodeItem
+                key={node.id}
+                node={node}
+                depth={0}
+                accentColor={accentColor}
+                expandedFolders={expandedFolders}
+                activeSlug={activeSlug}
+                onToggle={handleToggleFolder}
+                onCreateFolder={handleCreateFolder}
+                onCreateFile={handleCreateFile}
+              />
+            ))}
+          </ul>
+        </nav>
+      </div>
     </div>
   );
 }

--- a/components/editor/EditorShell.tsx
+++ b/components/editor/EditorShell.tsx
@@ -56,7 +56,7 @@ export default function EditorShell({ sidebar, children }: EditorShellProps) {
       >
         <header
           className="border-b border-[var(--editor-border)] px-8 py-6 backdrop-blur"
-          style={{ backgroundColor: "var(--editor-nav-bg)" }}
+          style={{ backgroundColor: "var(--editor-sidebar-bg)" }}
         >
           <div className="flex flex-wrap items-center justify-between gap-6">
             <Link
@@ -80,10 +80,10 @@ export default function EditorShell({ sidebar, children }: EditorShellProps) {
         </header>
         <div className="flex flex-1 overflow-hidden">
           <aside
-            className="flex w-80 min-w-[18rem] flex-col border-r border-[var(--editor-border)]"
+            className="flex w-64 min-w-[15rem] flex-col border-r border-[var(--editor-border)]"
             style={{ backgroundColor: "var(--editor-sidebar-bg)" }}
           >
-            <div className="flex-1 overflow-y-auto px-2 py-6">{sidebar}</div>
+            <div className="flex-1 overflow-y-auto px-2 py-6 sm:px-3">{sidebar}</div>
             <div
               className="border-t border-[var(--editor-subtle-border)] px-4 py-5"
               style={{ backgroundColor: "var(--editor-account-bg)" }}


### PR DESCRIPTION
## Summary
- align the editor header background with the sidebar styling and slim the navigation column
- streamline the account controls with a hover tooltip avatar and icon-based actions
- rebuild the drafts sidebar into a collapsible workspace tree with folder/file creation and a minimalist search bar

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc8326c52c8320b6278beab05d8891