### PR TITLE
Refine drafts sidebar and account popover

### DIFF
--- a/components/editor/AccountPanel.tsx
+++ b/components/editor/AccountPanel.tsx
@@ -17,6 +17,7 @@ export function AccountPanel() {
   const { accentColor } = useEditorTheme();
   const [account, setAccount] = useState<AccountSummary | null>(null);
   const [loading, setLoading] = useState(true);
+  const [showDetails, setShowDetails] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -61,26 +62,52 @@ export function AccountPanel() {
   return (
     <div className="space-y-4 text-sm text-[color:var(--editor-muted)]">
       <div className="flex items-center justify-between gap-3">
-        <Link
-          href="/account"
-          className="group relative flex h-11 w-11 items-center justify-center rounded-full text-base font-semibold transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-          style={{
-            backgroundColor: "var(--editor-soft)",
-            color: "var(--editor-page-text)",
-            boxShadow: "var(--editor-shadow)",
+        <div
+          className="relative"
+          onMouseEnter={() => setShowDetails(true)}
+          onMouseLeave={() => setShowDetails(false)}
+          onFocusCapture={() => setShowDetails(true)}
+          onBlurCapture={(event) => {
+            const next = event.relatedTarget as Node | null;
+            if (!next || !event.currentTarget.contains(next)) {
+              setShowDetails(false);
+            }
           }}
         >
-          <span aria-hidden>{initials}</span>
-          <span className="pointer-events-none absolute left-full top-1/2 z-10 ml-3 min-w-[12rem] -translate-y-1/2 rounded-md border border-[var(--editor-border)] bg-[var(--editor-surface)] px-3 py-2 text-left text-xs font-medium text-[color:var(--editor-page-text)] opacity-0 shadow-[var(--editor-shadow)] transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100">
-            <span className="block text-sm font-semibold">{accountName}</span>
-            {accountEmail && <span className="mt-1 block text-[0.7rem] text-[color:var(--editor-muted)]">{accountEmail}</span>}
-          </span>
-          <span className="sr-only">Open account</span>
-        </Link>
+          <button
+            type="button"
+            className="group flex h-11 w-11 items-center justify-center rounded-full text-base font-semibold transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            onClick={() => setShowDetails((prev) => !prev)}
+            style={{
+              backgroundColor: "var(--editor-soft)",
+              color: "var(--editor-page-text)",
+              boxShadow: "var(--editor-shadow)",
+            }}
+            aria-expanded={showDetails}
+            aria-haspopup="dialog"
+          >
+            <span aria-hidden>{initials}</span>
+            <span className="sr-only">View account details</span>
+          </button>
+          {showDetails && (
+            <div className="absolute left-full top-1/2 z-10 ml-3 min-w-[12rem] -translate-y-1/2 select-text border border-dashed border-[var(--editor-border)] bg-[var(--editor-surface)] px-3 py-2 text-left text-xs text-[color:var(--editor-page-text)] shadow-none">
+              <span className="block text-sm font-semibold">{accountName}</span>
+              {accountEmail && (
+                <span className="mt-1 block text-[0.7rem] text-[color:var(--editor-muted)]">{accountEmail}</span>
+              )}
+              <Link
+                href="/account"
+                className="mt-3 inline-flex items-center border border-dashed border-[var(--editor-border)] px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-[color:var(--editor-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+              >
+                Manage
+              </Link>
+            </div>
+          )}
+        </div>
         <div className="flex items-center gap-2">
           <Link
             href="/settings"
-            className="flex h-9 w-9 items-center justify-center rounded-md border border-[var(--editor-border)] text-base transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            className="flex h-9 w-9 items-center justify-center rounded-sm border border-dashed border-[var(--editor-border)] text-base transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
           >
             <span aria-hidden>⚙</span>
             <span className="sr-only">Open settings</span>
@@ -88,7 +115,7 @@ export function AccountPanel() {
           <button
             type="button"
             onClick={handleSignOut}
-            className="flex h-9 w-9 items-center justify-center rounded-md border border-[var(--editor-border)] text-base transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            className="flex h-9 w-9 items-center justify-center rounded-sm border border-dashed border-[var(--editor-border)] text-base transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
             style={{ color: accentColor }}
           >
             <span aria-hidden>⎋</span>

--- a/components/editor/DraftsSidebar.tsx
+++ b/components/editor/DraftsSidebar.tsx
@@ -163,7 +163,7 @@ function TreeNodeItem({
                 event.stopPropagation();
                 onCreateFolder(node.id);
               }}
-              className="flex h-7 w-7 items-center justify-center rounded border border-[var(--editor-border)] text-[0.7rem] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+              className="flex h-7 w-7 items-center justify-center rounded-sm border border-dashed border-[var(--editor-border)] text-[0.7rem] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
             >
               <span aria-hidden>📁+</span>
               <span className="sr-only">Create folder inside {node.name}</span>
@@ -174,7 +174,7 @@ function TreeNodeItem({
                 event.stopPropagation();
                 onCreateFile(node.id);
               }}
-              className="flex h-7 w-7 items-center justify-center rounded border border-[var(--editor-border)] text-[0.7rem] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+              className="flex h-7 w-7 items-center justify-center rounded-sm border border-dashed border-[var(--editor-border)] text-[0.7rem] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
             >
               <span aria-hidden>📄+</span>
               <span className="sr-only">Create file inside {node.name}</span>
@@ -385,58 +385,9 @@ export default function DraftsSidebar() {
   }, []);
 
   return (
-    <div className="flex h-full flex-col gap-5">
-      <div className="space-y-3">
-        <div className="flex items-center justify-between gap-3">
-          <h2 className="text-xs font-semibold uppercase tracking-[0.35em] text-[color:var(--editor-muted)]">
-            Drafts
-          </h2>
-          <Link
-            href="/write"
-            className="rounded-md bg-[var(--accent)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-[#1f0b2a] shadow-[0_12px_24px_-18px_rgba(212,175,227,0.8)] transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-          >
-            New
-          </Link>
-        </div>
-        <div className="relative">
-          <label className="sr-only" htmlFor="draft-search">
-            Search drafts
-          </label>
-          <input
-            id="draft-search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search drafts"
-            className="w-full border-0 border-b border-[var(--editor-border)] bg-transparent px-1 py-2 text-sm text-[color:var(--editor-page-text)] placeholder:text-[color:var(--editor-muted)] focus:border-[var(--accent)] focus:outline-none focus:ring-0"
-            type="search"
-          />
-        </div>
-      </div>
-      <div
-        className="flex flex-1 flex-col overflow-hidden rounded-xl border border-[var(--editor-border)] bg-[var(--editor-surface)] shadow-[var(--editor-shadow)]"
-      >
-        <div className="flex items-center justify-between border-b border-[var(--editor-subtle-border)] px-3 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-[color:var(--editor-muted)]">
-          <span>Workspace</span>
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={() => handleCreateFolder(null)}
-              className="flex h-8 w-8 items-center justify-center rounded-md border border-[var(--editor-border)] text-xs transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-            >
-              <span aria-hidden>🗂+</span>
-              <span className="sr-only">Create folder</span>
-            </button>
-            <button
-              type="button"
-              onClick={() => handleCreateFile(null)}
-              className="flex h-8 w-8 items-center justify-center rounded-md border border-[var(--editor-border)] text-xs transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-            >
-              <span aria-hidden>📄+</span>
-              <span className="sr-only">Create file</span>
-            </button>
-          </div>
-        </div>
-        <nav className="flex-1 overflow-y-auto px-1 py-3">
+    <div className="flex h-full flex-col gap-4">
+      <div className="flex-1 overflow-hidden border border-dashed border-[var(--editor-border)]">
+        <nav className="h-full overflow-y-auto px-2 py-3">
           <ul className="space-y-1 text-sm">
             {workspaceTree.map((node) => (
               <TreeNodeItem
@@ -453,6 +404,19 @@ export default function DraftsSidebar() {
             ))}
           </ul>
         </nav>
+      </div>
+      <div className="border border-dashed border-[var(--editor-border)] px-2 py-2">
+        <label className="sr-only" htmlFor="draft-search">
+          Search drafts
+        </label>
+        <input
+          id="draft-search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search drafts"
+          className="w-full border border-dashed border-[var(--editor-border)] bg-transparent px-2 py-2 text-sm text-[color:var(--editor-page-text)] placeholder:text-[color:var(--editor-muted)] focus:border-[var(--accent)] focus:outline-none focus:ring-0"
+          type="search"
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- simplify the drafts workspace by removing extra sections, using dashed borders, and moving search to the bottom
- update the account popover so it opens on hover/click, allows text selection, and aligns with the minimalist styling

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc8abd00ac8320a1bd84d5b62375ef