### PR TITLE
feat(editor): fetch workspace folders with actions

### DIFF
--- a/components/editor/DraftsSidebar.tsx
+++ b/components/editor/DraftsSidebar.tsx
@@ -3,39 +3,31 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { FolderPlus, FilePlus } from "lucide-react";
 
 import { createClient } from "@/lib/supabase/client";
 
 import { useEditorTheme } from "./EditorShell";
+import ItemActionMenu from "./ItemActionMenu";
 
 type DraftSummary = {
   readonly id: string;
   readonly title: string | null;
   readonly slug: string;
   readonly updated_at: string | null;
+  readonly folder_id: string | null;
 };
 
 type DraftEventDetail = {
   readonly id: string;
   readonly title?: string;
   readonly slug?: string;
+  readonly folder_id?: string | null;
 };
 
-type CustomFileNode = {
+type FolderSummary = {
   readonly id: string;
   readonly name: string;
-  readonly type: "file";
 };
-
-type CustomFolderNode = {
-  readonly id: string;
-  readonly name: string;
-  readonly type: "folder";
-  readonly children: readonly CustomTreeNode[];
-};
-
-type CustomTreeNode = CustomFolderNode | CustomFileNode;
 
 type DraftTreeNode = {
   readonly id: string;
@@ -43,21 +35,16 @@ type DraftTreeNode = {
   readonly type: "draft";
   readonly slug: string;
   readonly updatedAt: string | null;
+  readonly editable: boolean;
 };
 
 type FolderTreeNode = {
   readonly id: string;
   readonly name: string;
   readonly type: "folder";
-  readonly origin: "system" | "custom";
+  readonly origin: "system" | "remote";
+  readonly editable: boolean;
   readonly children: readonly TreeNode[];
-};
-
-type CustomFileTreeNode = {
-  readonly id: string;
-  readonly name: string;
-  readonly type: "file";
-  readonly origin: "custom";
 };
 
 type MessageTreeNode = {
@@ -66,7 +53,7 @@ type MessageTreeNode = {
   readonly type: "message";
 };
 
-type TreeNode = DraftTreeNode | FolderTreeNode | CustomFileTreeNode | MessageTreeNode;
+type TreeNode = DraftTreeNode | FolderTreeNode | MessageTreeNode;
 
 type TreeNodeItemProps = {
   readonly node: TreeNode;
@@ -75,52 +62,15 @@ type TreeNodeItemProps = {
   readonly expandedFolders: readonly string[];
   readonly activeSlug: string | null;
   readonly onToggle: (folderId: string) => void;
-  readonly onCreateFolder: (parentId: string | null) => void;
-  readonly onCreateFile: (parentId: string | null) => void;
+  readonly onRenameFolder: (folderId: string) => void;
+  readonly onDeleteFolder: (folderId: string) => void;
+  readonly onRenameDraft: (draftId: string) => void;
+  readonly onDeleteDraft: (draftId: string) => void;
 };
+
+const UNFILED_FOLDER_ID = "workspace-unfiled";
 
 const toTitle = (title: string | null) => (title && title.trim().length > 0 ? title : "Untitled draft");
-
-const createNodeId = (prefix: string) => {
-  const random = globalThis.crypto?.randomUUID?.();
-  if (random) {
-    return `${prefix}-${random}`;
-  }
-  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
-};
-
-const addCustomNode = (
-  nodes: readonly CustomTreeNode[],
-  parentId: string | null,
-  newNode: CustomTreeNode,
-): readonly CustomTreeNode[] => {
-  if (!parentId) {
-    return [...nodes, newNode];
-  }
-
-  return nodes.map((node) => {
-    if (node.type !== "folder") {
-      return node;
-    }
-    if (node.id === parentId) {
-      return { ...node, children: [...node.children, newNode] };
-    }
-    return { ...node, children: addCustomNode(node.children, parentId, newNode) };
-  });
-};
-
-const convertCustomNodes = (nodes: readonly CustomTreeNode[]): readonly TreeNode[] =>
-  nodes.map((node) =>
-    node.type === "folder"
-      ? {
-          id: node.id,
-          name: node.name,
-          type: "folder" as const,
-          origin: "custom" as const,
-          children: convertCustomNodes(node.children),
-        }
-      : { id: node.id, name: node.name, type: "file" as const, origin: "custom" as const },
-  );
 
 const formatUpdatedAt = (updatedAt: string | null) =>
   updatedAt ? new Date(updatedAt).toLocaleString() : "Never saved";
@@ -132,8 +82,10 @@ function TreeNodeItem({
   expandedFolders,
   activeSlug,
   onToggle,
-  onCreateFolder,
-  onCreateFile,
+  onRenameFolder,
+  onDeleteFolder,
+  onRenameDraft,
+  onDeleteDraft,
 }: TreeNodeItemProps) {
   const indentStyle = { paddingLeft: `${depth * 0.75}rem` };
 
@@ -157,30 +109,14 @@ function TreeNodeItem({
             <span aria-hidden className="text-base">{node.origin === "system" ? "📂" : "🗂"}</span>
             <span className="truncate">{node.name}</span>
           </button>
-          <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-            <button
-              type="button"
-              onClick={(event) => {
-                event.stopPropagation();
-                onCreateFolder(node.id);
-              }}
-              className="flex h-7 w-7 items-center justify-center rounded-sm border border-dashed border-[var(--editor-border)] text-[0.7rem] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-            >
-              <span aria-hidden>📁+</span>
-              <span className="sr-only">Create folder inside {node.name}</span>
-            </button>
-            <button
-              type="button"
-              onClick={(event) => {
-                event.stopPropagation();
-                onCreateFile(node.id);
-              }}
-              className="flex h-7 w-7 items-center justify-center rounded-sm border border-dashed border-[var(--editor-border)] text-[0.7rem] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-            >
-              <span aria-hidden>📄+</span>
-              <span className="sr-only">Create file inside {node.name}</span>
-            </button>
-          </div>
+          {node.editable && (
+            <ItemActionMenu
+              ariaLabel={`Folder actions for ${node.name}`}
+              className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+              onDelete={() => onDeleteFolder(node.id)}
+              onRename={() => onRenameFolder(node.id)}
+            />
+          )}
         </div>
         {isExpanded && node.children.length > 0 && (
           <ul className="mt-1 space-y-1">
@@ -193,8 +129,10 @@ function TreeNodeItem({
                 expandedFolders={expandedFolders}
                 activeSlug={activeSlug}
                 onToggle={onToggle}
-                onCreateFolder={onCreateFolder}
-                onCreateFile={onCreateFile}
+                onRenameFolder={onRenameFolder}
+                onDeleteFolder={onDeleteFolder}
+                onRenameDraft={onRenameDraft}
+                onDeleteDraft={onDeleteDraft}
               />
             ))}
           </ul>
@@ -208,35 +146,32 @@ function TreeNodeItem({
 
     return (
       <li>
-        <Link
-          href={`/write/${node.slug}`}
-          className="group flex items-center gap-2 rounded-md px-2 py-1 text-sm transition-colors hover:bg-[var(--editor-soft)]"
+        <div
+          className="group flex items-center justify-between gap-2 rounded-md px-2 py-1 text-sm transition-colors hover:bg-[var(--editor-soft)]"
           style={{
             ...indentStyle,
             color: isActive ? accentColor : "var(--editor-page-text)",
-            borderColor: isActive ? accentColor : undefined,
             backgroundColor: isActive ? "var(--editor-soft)" : undefined,
           }}
-          title={formatUpdatedAt(node.updatedAt)}
         >
-          <span aria-hidden className="text-base">📄</span>
-          <span className="truncate group-hover:text-[var(--accent)]" style={isActive ? { color: accentColor } : undefined}>
-            {node.name}
-          </span>
-        </Link>
-      </li>
-    );
-  }
-
-  if (node.type === "file") {
-    return (
-      <li>
-        <div
-          className="flex items-center gap-2 rounded-md px-2 py-1 text-sm text-[color:var(--editor-muted)]"
-          style={indentStyle}
-        >
-          <span aria-hidden className="text-base">📝</span>
-          <span className="truncate">{node.name}</span>
+          <Link
+            href={`/write/${node.slug}`}
+            className="flex min-w-0 flex-1 items-center gap-2"
+            title={formatUpdatedAt(node.updatedAt)}
+          >
+            <span aria-hidden className="text-base">📄</span>
+            <span className="truncate group-hover:text-[var(--accent)]" style={isActive ? { color: accentColor } : undefined}>
+              {node.name}
+            </span>
+          </Link>
+          {node.editable && (
+            <ItemActionMenu
+              ariaLabel={`Draft actions for ${node.name}`}
+              className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+              onDelete={() => onDeleteDraft(node.id)}
+              onRename={() => onRenameDraft(node.id)}
+            />
+          )}
         </div>
       </li>
     );
@@ -261,8 +196,10 @@ export default function DraftsSidebar() {
   const [drafts, setDrafts] = useState<readonly DraftSummary[]>([]);
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(true);
-  const [customTree, setCustomTree] = useState<readonly CustomTreeNode[]>([]);
-  const [expandedFolders, setExpandedFolders] = useState<readonly string[]>(["drafts-root"]);
+  const [expandedFolders, setExpandedFolders] = useState<readonly string[]>([UNFILED_FOLDER_ID]);
+  const [folders, setFolders] = useState<readonly FolderSummary[]>([]);
+  const [foldersLoading, setFoldersLoading] = useState(true);
+  const [foldersError, setFoldersError] = useState<string | null>(null);
 
   const fetchDrafts = useMemo(
     () =>
@@ -270,7 +207,7 @@ export default function DraftsSidebar() {
         setLoading(true);
         const { data, error } = await supabase
           .from("posts")
-          .select("id,title,slug,updated_at")
+          .select("id,title,slug,updated_at,folder_id")
           .eq("status", "draft")
           .eq("is_deleted", false)
           .order("updated_at", { ascending: false })
@@ -283,18 +220,37 @@ export default function DraftsSidebar() {
     [supabase],
   );
 
+  const fetchFolders = useMemo(
+    () =>
+      async () => {
+        setFoldersLoading(true);
+        setFoldersError(null);
+        const { data, error } = await supabase
+          .from("folders")
+          .select("id,name")
+          .order("name", { ascending: true });
+        if (error) {
+          setFoldersError(error.message);
+          setFolders([]);
+        } else {
+          setFolders(data ?? []);
+        }
+        setFoldersLoading(false);
+      },
+    [supabase],
+  );
+
   useEffect(() => {
     fetchDrafts();
-  }, [fetchDrafts]);
+    fetchFolders();
+  }, [fetchDrafts, fetchFolders]);
 
   useEffect(() => {
     const onRefresh = () => fetchDrafts();
     const onDraftUpdated: EventListener = (event) => {
       const detail = (event as CustomEvent<DraftEventDetail>).detail;
       if (!detail) return;
-      setDrafts((prev) =>
-        prev.map((draft) => (draft.id === detail.id ? { ...draft, ...detail } : draft)),
-      );
+      setDrafts((prev) => prev.map((draft) => (draft.id === detail.id ? { ...draft, ...detail } : draft)));
     };
 
     window.addEventListener("editor:refresh-drafts", onRefresh);
@@ -317,36 +273,97 @@ export default function DraftsSidebar() {
   }, [pathname]);
 
   const workspaceTree = useMemo(() => {
-    const draftChildren: readonly TreeNode[] = loading
-      ? [{ id: "drafts-loading", type: "message", message: "Loading drafts…" }]
-      : filteredDrafts.length > 0
-        ? filteredDrafts.map((draft) => ({
-            id: draft.id,
-            name: toTitle(draft.title),
-            type: "draft" as const,
-            slug: draft.slug,
-            updatedAt: draft.updated_at,
-          }))
+    if (loading) {
+      return [{ id: "drafts-loading", type: "message" as const, message: "Loading drafts…" }];
+    }
+
+    if (filteredDrafts.length === 0) {
+      return [
+        {
+          id: "workspace-empty",
+          type: "message" as const,
+          message:
+            query.trim().length > 0
+              ? "No drafts match your search."
+              : "No drafts yet. Start something new.",
+        },
+      ];
+    }
+
+    const draftNodesByFolder = filteredDrafts.reduce((acc, draft) => {
+      const folderId = draft.folder_id ?? null;
+      const list = acc.get(folderId) ?? [];
+      list.push({
+        id: draft.id,
+        name: toTitle(draft.title),
+        type: "draft" as const,
+        slug: draft.slug,
+        updatedAt: draft.updated_at,
+        editable: true,
+      });
+      acc.set(folderId, list);
+      return acc;
+    }, new Map<string | null, DraftTreeNode[]>());
+
+    const nodes: TreeNode[] = [];
+
+    if (foldersError) {
+      nodes.push({
+        id: "folders-error",
+        type: "message" as const,
+        message: "Unable to load folders. Showing drafts without folders.",
+      });
+    }
+
+    const unfiledDrafts = draftNodesByFolder.get(null) ?? [];
+    if (unfiledDrafts.length > 0) {
+      nodes.push({
+        id: UNFILED_FOLDER_ID,
+        name: "Unfiled",
+        type: "folder" as const,
+        origin: "system" as const,
+        editable: false,
+        children: unfiledDrafts,
+      });
+    }
+
+    if (!foldersLoading && folders.length === 0) {
+      return nodes.length > 0
+        ? nodes
         : [
             {
-              id: "drafts-empty",
+              id: "workspace-no-folders",
               type: "message" as const,
-              message: query.trim().length > 0 ? "No drafts match your search." : "No drafts yet. Start something new.",
+              message: "No folders yet. Create one from Supabase to get started.",
             },
           ];
+    }
 
-    const draftsFolder: FolderTreeNode = {
-      id: "drafts-root",
-      name: "Drafts",
-      type: "folder",
-      origin: "system",
-      children: draftChildren,
-    };
+    const folderNodes = folders.map((folder) => {
+      const folderDrafts = draftNodesByFolder.get(folder.id) ?? [];
+      const children: readonly TreeNode[] =
+        folderDrafts.length > 0
+          ? folderDrafts
+          : [
+              {
+                id: `${folder.id}-empty`,
+                type: "message" as const,
+                message: "No drafts in this folder.",
+              },
+            ];
 
-    const customNodes = convertCustomNodes(customTree);
+      return {
+        id: folder.id,
+        name: folder.name,
+        type: "folder" as const,
+        origin: "remote" as const,
+        editable: true,
+        children,
+      } satisfies FolderTreeNode;
+    });
 
-    return [draftsFolder, ...customNodes];
-  }, [customTree, filteredDrafts, loading, query]);
+    return [...nodes, ...folderNodes];
+  }, [filteredDrafts, folders, foldersError, foldersLoading, loading, query]);
 
   const handleToggleFolder = useCallback((folderId: string) => {
     setExpandedFolders((prev) =>
@@ -354,78 +371,135 @@ export default function DraftsSidebar() {
     );
   }, []);
 
-  const handleCreateFolder = useCallback((parentId: string | null) => {
-    const name = window.prompt("Name this folder");
-    const trimmed = name?.trim();
-    if (!trimmed) {
-      return;
-    }
-    const id = createNodeId("folder");
-    setCustomTree((prev) => addCustomNode(prev, parentId, { type: "folder", id, name: trimmed, children: [] }));
-    setExpandedFolders((prev) => {
-      const next = new Set(prev);
-      if (parentId) {
-        next.add(parentId);
+  const handleRenameFolder = useCallback(
+    async (folderId: string) => {
+      const newName = window.prompt("Rename folder");
+      const trimmed = newName?.trim();
+      if (!trimmed) {
+        return;
       }
-      next.add(id);
-      return Array.from(next);
-    });
-  }, []);
 
-  const handleCreateFile = useCallback((parentId: string | null) => {
-    const name = window.prompt("Name this file");
-    const trimmed = name?.trim();
-    if (!trimmed) {
-      return;
-    }
-    const id = createNodeId("file");
-    setCustomTree((prev) => addCustomNode(prev, parentId, { type: "file", id, name: trimmed }));
-    if (parentId) {
-      setExpandedFolders((prev) => (prev.includes(parentId) ? prev : [...prev, parentId]));
-    }
-  }, []);
+      const { data, error } = await supabase
+        .from("folders")
+        .update({ name: trimmed })
+        .eq("id", folderId)
+        .select("id,name")
+        .single();
+
+      if (error) {
+        window.alert(`Unable to rename folder: ${error.message}`);
+        return;
+      }
+
+      if (data) {
+        setFolders((prev) => prev.map((folder) => (folder.id === data.id ? { ...folder, name: data.name } : folder)));
+      }
+    },
+    [supabase],
+  );
+
+  const handleDeleteFolder = useCallback(
+    async (folderId: string) => {
+      const confirmed = window.confirm("Delete this folder? Drafts will be moved to Unfiled.");
+      if (!confirmed) {
+        return;
+      }
+
+      const { error } = await supabase.from("folders").delete().eq("id", folderId);
+      if (error) {
+        window.alert(`Unable to delete folder: ${error.message}`);
+        return;
+      }
+
+      setFolders((prev) => prev.filter((folder) => folder.id !== folderId));
+      setDrafts((prev) =>
+        prev.map((draft) => (draft.folder_id === folderId ? { ...draft, folder_id: null } : draft)),
+      );
+      setExpandedFolders((prev) => prev.filter((id) => id !== folderId));
+    },
+    [supabase],
+  );
+
+  const handleRenameDraft = useCallback(
+    async (draftId: string) => {
+      const newTitle = window.prompt("Rename draft");
+      const trimmed = newTitle?.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      const { data, error } = await supabase
+        .from("posts")
+        .update({ title: trimmed })
+        .eq("id", draftId)
+        .select("id,title,slug,updated_at,folder_id")
+        .single();
+
+      if (error) {
+        window.alert(`Unable to rename draft: ${error.message}`);
+        return;
+      }
+
+      if (data) {
+        setDrafts((prev) => prev.map((draft) => (draft.id === data.id ? data : draft)));
+      }
+    },
+    [supabase],
+  );
+
+  const handleDeleteDraft = useCallback(
+    async (draftId: string) => {
+      const confirmed = window.confirm("Delete this draft?");
+      if (!confirmed) {
+        return;
+      }
+
+      const { error } = await supabase
+        .from("posts")
+        .update({ is_deleted: true })
+        .eq("id", draftId);
+
+      if (error) {
+        window.alert(`Unable to delete draft: ${error.message}`);
+        return;
+      }
+
+      setDrafts((prev) => prev.filter((draft) => draft.id !== draftId));
+    },
+    [supabase],
+  );
 
   return (
     <div className="flex h-full flex-col gap-5">
       <div
         className="flex flex-1 flex-col overflow-hidden border-none border-[var(--editor-border)]  shadow-[var(--editor-shadow)]"
       >
-        <div className="flex items-center justify-between border-none border-[var(--editor-subtle-border)] px-3 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-[color:var(--editor-muted)]">
+        <div className="flex items-center justify-between border-none border-[var(--editor-subtle-border)] px-3 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-[color:var(--editor-muted)] transition-colors hover:bg-[var(--editor-soft)] hover:text-[color:var(--editor-page-text)]">
           <span>Workspace</span>
-          <div className="flex items-center gap-1">
-             <button
-              type="button"
-              onClick={() => handleCreateFile(null)}
-              className="flex h-8 w-8 items-center justify-center border-none text-md transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-            >
-              <FilePlus size={16} />
-              <span className="sr-only">Create file</span>
-            </button>
-            <button
-              type="button"
-              onClick={() => handleCreateFolder(null)}
-              className="flex h-8 w-8 items-center justify-center  border-none text-md transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-            >
-              <FolderPlus size={16} />
-              <span className="sr-only">Create folder</span>
-            </button>
-          </div>
         </div>
         <nav className="flex-1 overflow-y-auto px-1 py-3">
           <ul className="space-y-1 text-sm">
-            {workspaceTree.map((node) => (
-              <TreeNodeItem
-                key={node.id}
-                node={node}
-                depth={0}
-                accentColor={accentColor}
-                expandedFolders={expandedFolders}
-                activeSlug={activeSlug}
-                onToggle={handleToggleFolder}
-                onCreateFolder={handleCreateFolder}
-                onCreateFile={handleCreateFile}
-              />
-            ))}
+            {foldersLoading && folders.length === 0 ? (
+              <li>
+                <div className="px-2 py-1 text-[0.8rem] text-[color:var(--editor-muted)]">Loading folders…</div>
+              </li>
+            ) : (
+              workspaceTree.map((node) => (
+                <TreeNodeItem
+                  key={node.id}
+                  node={node}
+                  depth={0}
+                  accentColor={accentColor}
+                  expandedFolders={expandedFolders}
+                  activeSlug={activeSlug}
+                  onToggle={handleToggleFolder}
+                  onRenameFolder={handleRenameFolder}
+                  onDeleteFolder={handleDeleteFolder}
+                  onRenameDraft={handleRenameDraft}
+                  onDeleteDraft={handleDeleteDraft}
+                />
+              ))
+            )}
           </ul>
         </nav>
       </div>

--- a/components/editor/ItemActionMenu.tsx
+++ b/components/editor/ItemActionMenu.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MoreVertical } from "lucide-react";
+
+type ItemActionMenuProps = {
+  readonly ariaLabel: string;
+  readonly className?: string;
+  readonly onRename?: () => void;
+  readonly onDelete?: () => void;
+};
+
+export default function ItemActionMenu({
+  ariaLabel,
+  className,
+  onRename,
+  onDelete,
+}: ItemActionMenuProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!containerRef.current) {
+        return;
+      }
+      if (!containerRef.current.contains(event.target as Node)) {
+        close();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        close();
+      }
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [close, open]);
+
+  const handleToggle = useCallback(() => {
+    setOpen((prev) => !prev);
+  }, []);
+
+  const handleRename = useCallback(() => {
+    close();
+    onRename?.();
+  }, [close, onRename]);
+
+  const handleDelete = useCallback(() => {
+    close();
+    onDelete?.();
+  }, [close, onDelete]);
+
+  return (
+    <div ref={containerRef} className={`relative ${className ?? ""}`}>
+      <button
+        type="button"
+        onClick={handleToggle}
+        className="flex h-6 w-6 items-center justify-center rounded-sm text-[color:var(--editor-muted)] transition-colors hover:text-[var(--editor-page-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+      >
+        <MoreVertical className="h-4 w-4" aria-hidden />
+      </button>
+      {open && (
+        <div className="absolute right-0 z-20 mt-1 w-36 rounded-md border border-[var(--editor-border)] bg-[var(--editor-page)] p-1 text-left shadow-lg">
+          {onRename && (
+            <button
+              type="button"
+              onClick={handleRename}
+              className="flex w-full items-center gap-2 rounded-sm px-2 py-1 text-sm text-[color:var(--editor-page-text)] transition-colors hover:bg-[var(--editor-soft)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            >
+              Rename
+            </button>
+          )}
+          {onDelete && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              className="flex w-full items-center gap-2 rounded-sm px-2 py-1 text-sm text-[color:var(--editor-danger, #d92c20)] transition-colors hover:bg-[var(--editor-soft)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the drafts sidebar workspace tree with Supabase-backed folders and an unfiled section, dropping the old default Drafts node and highlighting the Workspace header on hover
- add contextual action menus that allow renaming or deleting folders and drafts within the sidebar

## Testing
- `npm run build` *(fails: unable to fetch Google Fonts in the container)*
- `npx tsc --noEmit` *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc963b317083208e07a8aafc030a15