### PR TITLE
Add workspace creation controls for drafts and folders

### DIFF
--- a/app/write/layout.tsx
+++ b/app/write/layout.tsx
@@ -1,8 +1,36 @@
 
+import { redirect } from "next/navigation";
+
 import DraftsSidebar from "@/components/editor/DraftsSidebar";
 import EditorShell from "@/components/editor/EditorShell";
+import { createClient } from "@/lib/supabase/server";
 
-export default function WriteLayout({ children }: { children: React.ReactNode }) {
+export default async function WriteLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    redirect("/");
+  }
+
+  const { data: owner, error: ownerError } = await supabase
+    .from("blog_owner")
+    .select("owner_id")
+    .eq("owner_id", user.id)
+    .maybeSingle();
+
+  if (ownerError || !owner) {
+    redirect("/");
+  }
+
   return <EditorShell sidebar={<DraftsSidebar />}>{children}</EditorShell>;
 }
 


### PR DESCRIPTION
## Summary
- conditionally show workspace creation controls after verifying the current user is the blog owner
- restore folder and draft creation actions with FolderPlus/FilePlus icons that persist new records to Supabase
- gate the entire write workspace route behind a server-side blog owner check

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc9b1477dc83209b7f8bcc2c89d7d5