### PR TITLE
Make Supabase server client async

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -5,7 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 export const dynamic = "force-dynamic";
 
 export default async function HomePage() {
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("posts")
     .select("*")

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -22,7 +22,7 @@ type PostPageProps = {
 };
 
 export default async function PostPage({ params }: PostPageProps) {
-  const supabase = createClient();
+  const supabase = await createClient();
   const { data, error } = await supabase
     .from("posts")
     .select("title,slug,content_json,published_at,excerpt,summary")

--- a/app/write/layout.tsx
+++ b/app/write/layout.tsx
@@ -10,7 +10,7 @@ export default async function WriteLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const supabase = createClient();
+  const supabase = await createClient();
 
   const {
     data: { user },

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,8 +1,8 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
-export const createClient = () => {
-  const cookieStore = cookies();
+export const createClient = async () => {
+  const cookieStore = await cookies();
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
## Summary
- make the Supabase server client factory asynchronous so it uses the resolved cookie store
- update server components to await the Supabase client before issuing queries

## Testing
- npm run build *(fails: unable to fetch Google Font due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dca49b2e24832088562d7cf69d15be