### PR TITLE
Enable inline renaming in write workspace

### DIFF
--- a/components/editor/DraftsSidebar.tsx
+++ b/components/editor/DraftsSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 
@@ -68,6 +68,12 @@ type TreeNodeItemProps = {
   readonly onDeleteFolder: (folderId: string) => void;
   readonly onRenameDraft: (draftId: string) => void;
   readonly onDeleteDraft: (draftId: string) => void;
+  readonly renamingFolderId: string | null;
+  readonly renamingDraftId: string | null;
+  readonly onSubmitFolderRename: (folderId: string, name: string) => Promise<void>;
+  readonly onSubmitDraftRename: (draftId: string, name: string) => Promise<void>;
+  readonly onCancelFolderRename: () => void;
+  readonly onCancelDraftRename: () => void;
 };
 
 const UNFILED_FOLDER_ID = "workspace-unfiled";
@@ -88,11 +94,143 @@ function TreeNodeItem({
   onDeleteFolder,
   onRenameDraft,
   onDeleteDraft,
+  renamingFolderId,
+  renamingDraftId,
+  onSubmitFolderRename,
+  onSubmitDraftRename,
+  onCancelFolderRename,
+  onCancelDraftRename,
 }: TreeNodeItemProps) {
   const indentStyle = { paddingLeft: `${depth * 0.75}rem` };
+  const [folderName, setFolderName] = useState(node.type === "folder" ? node.name : "");
+  const [draftName, setDraftName] = useState(node.type === "draft" ? node.name : "");
+  const [folderSubmitting, setFolderSubmitting] = useState(false);
+  const [draftSubmitting, setDraftSubmitting] = useState(false);
+  const folderInputRef = useRef<HTMLInputElement | null>(null);
+  const draftInputRef = useRef<HTMLInputElement | null>(null);
+  const folderSubmitRef = useRef(false);
+  const draftSubmitRef = useRef(false);
+
+  useEffect(() => {
+    if (node.type === "folder" && renamingFolderId !== node.id) {
+      setFolderName(node.name);
+    }
+  }, [node, renamingFolderId]);
+
+  useEffect(() => {
+    if (node.type === "draft" && renamingDraftId !== node.id) {
+      setDraftName(node.name);
+    }
+  }, [node, renamingDraftId]);
+
+  useEffect(() => {
+    if (node.type === "folder" && renamingFolderId === node.id) {
+      const frame = requestAnimationFrame(() => {
+        folderInputRef.current?.select();
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+    return undefined;
+  }, [node, renamingFolderId]);
+
+  useEffect(() => {
+    if (node.type === "draft" && renamingDraftId === node.id) {
+      const frame = requestAnimationFrame(() => {
+        draftInputRef.current?.select();
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+    return undefined;
+  }, [node, renamingDraftId]);
+
+  const commitFolderRename = useCallback(async () => {
+    if (node.type !== "folder") {
+      return;
+    }
+    if (renamingFolderId !== node.id) {
+      return;
+    }
+    if (folderSubmitting) {
+      return;
+    }
+
+    const trimmed = folderName.trim();
+    if (trimmed.length === 0) {
+      setFolderName(node.name);
+      onCancelFolderRename();
+      return;
+    }
+
+    if (trimmed === node.name) {
+      onCancelFolderRename();
+      return;
+    }
+
+    try {
+      setFolderSubmitting(true);
+      await onSubmitFolderRename(node.id, trimmed);
+    } finally {
+      setFolderSubmitting(false);
+    }
+  }, [folderName, folderSubmitting, node, onCancelFolderRename, onSubmitFolderRename, renamingFolderId]);
+
+  const commitDraftRename = useCallback(async () => {
+    if (node.type !== "draft") {
+      return;
+    }
+    if (renamingDraftId !== node.id) {
+      return;
+    }
+    if (draftSubmitting) {
+      return;
+    }
+
+    const trimmed = draftName.trim();
+    if (trimmed.length === 0) {
+      setDraftName(node.name);
+      onCancelDraftRename();
+      return;
+    }
+
+    if (trimmed === node.name) {
+      onCancelDraftRename();
+      return;
+    }
+
+    try {
+      setDraftSubmitting(true);
+      await onSubmitDraftRename(node.id, trimmed);
+    } finally {
+      setDraftSubmitting(false);
+    }
+  }, [draftName, draftSubmitting, node, onCancelDraftRename, onSubmitDraftRename, renamingDraftId]);
 
   if (node.type === "folder") {
     const isExpanded = expandedFolders.includes(node.id);
+    const isRenaming = renamingFolderId === node.id;
+
+    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      folderSubmitRef.current = true;
+      await commitFolderRename();
+      folderSubmitRef.current = false;
+    };
+
+    const handleBlur = async () => {
+      if (folderSubmitRef.current) {
+        folderSubmitRef.current = false;
+        return;
+      }
+      await commitFolderRename();
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setFolderName(node.name);
+        onCancelFolderRename();
+      }
+    };
 
     return (
       <li>
@@ -100,18 +238,39 @@ function TreeNodeItem({
           className="group flex items-center justify-between rounded-md px-2 py-1 text-sm font-medium text-[color:var(--editor-muted)] transition-colors hover:bg-[var(--editor-soft)] hover:text-[color:var(--editor-page-text)]"
           style={indentStyle}
         >
-          <button
-            type="button"
-            onClick={() => onToggle(node.id)}
-            className="flex flex-1 items-center gap-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-          >
-            <span aria-hidden className="text-[0.65rem]">
-              {isExpanded ? "▾" : "▸"}
-            </span>
-            <span aria-hidden className="text-base">{node.origin === "system" ? "📂" : "🗂"}</span>
-            <span className="truncate">{node.name}</span>
-          </button>
-          {node.editable && (
+          <div className="flex flex-1 items-center gap-2">
+            <button
+              type="button"
+              onClick={() => onToggle(node.id)}
+              className="flex items-center gap-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            >
+              <span aria-hidden className="text-[0.65rem]">{isExpanded ? "▾" : "▸"}</span>
+              <span aria-hidden className="text-base">{node.origin === "system" ? "📂" : "🗂"}</span>
+            </button>
+            {isRenaming ? (
+              <form onSubmit={handleSubmit} className="flex-1" spellCheck={false}>
+                <input
+                  ref={folderInputRef}
+                  value={folderName}
+                  onChange={(event) => setFolderName(event.target.value)}
+                  onBlur={handleBlur}
+                  onKeyDown={handleKeyDown}
+                  className="w-full rounded-sm border border-[var(--editor-border)] bg-transparent px-2 py-1 text-sm text-[color:var(--editor-page-text)] focus:border-[var(--accent)] focus:outline-none focus:ring-0"
+                  aria-label="Folder name"
+                  disabled={folderSubmitting}
+                />
+              </form>
+            ) : (
+              <button
+                type="button"
+                onClick={() => onToggle(node.id)}
+                className="flex flex-1 items-center gap-2 truncate text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+              >
+                <span className="truncate">{node.name}</span>
+              </button>
+            )}
+          </div>
+          {node.editable && !isRenaming && (
             <ItemActionMenu
               ariaLabel={`Folder actions for ${node.name}`}
               className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
@@ -135,6 +294,12 @@ function TreeNodeItem({
                 onDeleteFolder={onDeleteFolder}
                 onRenameDraft={onRenameDraft}
                 onDeleteDraft={onDeleteDraft}
+                renamingFolderId={renamingFolderId}
+                renamingDraftId={renamingDraftId}
+                onSubmitFolderRename={onSubmitFolderRename}
+                onSubmitDraftRename={onSubmitDraftRename}
+                onCancelFolderRename={onCancelFolderRename}
+                onCancelDraftRename={onCancelDraftRename}
               />
             ))}
           </ul>
@@ -145,6 +310,30 @@ function TreeNodeItem({
 
   if (node.type === "draft") {
     const isActive = activeSlug === node.slug;
+    const isRenaming = renamingDraftId === node.id;
+
+    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      draftSubmitRef.current = true;
+      await commitDraftRename();
+      draftSubmitRef.current = false;
+    };
+
+    const handleBlur = async () => {
+      if (draftSubmitRef.current) {
+        draftSubmitRef.current = false;
+        return;
+      }
+      await commitDraftRename();
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setDraftName(node.name);
+        onCancelDraftRename();
+      }
+    };
 
     return (
       <li>
@@ -156,17 +345,36 @@ function TreeNodeItem({
             backgroundColor: isActive ? "var(--editor-soft)" : undefined,
           }}
         >
-          <Link
-            href={`/write/${node.slug}`}
-            className="flex min-w-0 flex-1 items-center gap-2"
-            title={formatUpdatedAt(node.updatedAt)}
-          >
-            <span aria-hidden className="text-base">📄</span>
-            <span className="truncate group-hover:text-[var(--accent)]" style={isActive ? { color: accentColor } : undefined}>
-              {node.name}
-            </span>
-          </Link>
-          {node.editable && (
+          {isRenaming ? (
+            <form onSubmit={handleSubmit} className="flex min-w-0 flex-1 items-center gap-2" spellCheck={false}>
+              <span aria-hidden className="text-base">📄</span>
+              <input
+                ref={draftInputRef}
+                value={draftName}
+                onChange={(event) => setDraftName(event.target.value)}
+                onBlur={handleBlur}
+                onKeyDown={handleKeyDown}
+                className="w-full rounded-sm border border-[var(--editor-border)] bg-transparent px-2 py-1 text-sm text-[color:var(--editor-page-text)] focus:border-[var(--accent)] focus:outline-none focus:ring-0"
+                aria-label="Draft title"
+                disabled={draftSubmitting}
+              />
+            </form>
+          ) : (
+            <Link
+              href={`/write/${node.slug}`}
+              className="flex min-w-0 flex-1 items-center gap-2"
+              title={formatUpdatedAt(node.updatedAt)}
+            >
+              <span aria-hidden className="text-base">📄</span>
+              <span
+                className="truncate group-hover:text-[var(--accent)]"
+                style={isActive ? { color: accentColor } : undefined}
+              >
+                {node.name}
+              </span>
+            </Link>
+          )}
+          {node.editable && !isRenaming && (
             <ItemActionMenu
               ariaLabel={`Draft actions for ${node.name}`}
               className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
@@ -205,6 +413,8 @@ export default function DraftsSidebar() {
   const [foldersError, setFoldersError] = useState<string | null>(null);
   const [canManageWorkspace, setCanManageWorkspace] = useState(false);
   const [checkingOwner, setCheckingOwner] = useState(true);
+  const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null);
+  const [renamingDraftId, setRenamingDraftId] = useState<string | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -343,7 +553,7 @@ export default function DraftsSidebar() {
         type: "draft" as const,
         slug: draft.slug,
         updatedAt: draft.updated_at,
-        editable: true,
+        editable: canManageWorkspace,
       });
       acc.set(folderId, list);
       return acc;
@@ -401,13 +611,13 @@ export default function DraftsSidebar() {
         name: folder.name,
         type: "folder" as const,
         origin: "remote" as const,
-        editable: true,
+        editable: canManageWorkspace,
         children,
       } satisfies FolderTreeNode;
     });
 
     return [...nodes, ...folderNodes];
-  }, [filteredDrafts, folders, foldersError, foldersLoading, loading, query]);
+  }, [canManageWorkspace, filteredDrafts, folders, foldersError, foldersLoading, loading, query]);
 
   const handleToggleFolder = useCallback((folderId: string) => {
     setExpandedFolders((prev) =>
@@ -415,11 +625,22 @@ export default function DraftsSidebar() {
     );
   }, []);
 
-  const handleRenameFolder = useCallback(
-    async (folderId: string) => {
-      const newName = window.prompt("Rename folder");
-      const trimmed = newName?.trim();
-      if (!trimmed) {
+  const handleStartRenameFolder = useCallback((folderId: string) => {
+    setRenamingDraftId(null);
+    setRenamingFolderId(folderId);
+  }, []);
+
+  const handleSubmitFolderRename = useCallback(
+    async (folderId: string, name: string) => {
+      const trimmed = name.trim();
+      if (trimmed.length === 0) {
+        window.alert("Folder name cannot be empty.");
+        return;
+      }
+
+      const existing = folders.find((folder) => folder.id === folderId);
+      if (existing && existing.name === trimmed) {
+        setRenamingFolderId(null);
         return;
       }
 
@@ -438,9 +659,14 @@ export default function DraftsSidebar() {
       if (data) {
         setFolders((prev) => prev.map((folder) => (folder.id === data.id ? { ...folder, name: data.name } : folder)));
       }
+      setRenamingFolderId(null);
     },
-    [supabase],
+    [folders, supabase],
   );
+
+  const handleCancelFolderRename = useCallback(() => {
+    setRenamingFolderId(null);
+  }, []);
 
   const handleDeleteFolder = useCallback(
     async (folderId: string) => {
@@ -460,15 +686,27 @@ export default function DraftsSidebar() {
         prev.map((draft) => (draft.folder_id === folderId ? { ...draft, folder_id: null } : draft)),
       );
       setExpandedFolders((prev) => prev.filter((id) => id !== folderId));
+      setRenamingFolderId((prev) => (prev === folderId ? null : prev));
     },
     [supabase],
   );
 
-  const handleRenameDraft = useCallback(
-    async (draftId: string) => {
-      const newTitle = window.prompt("Rename draft");
-      const trimmed = newTitle?.trim();
-      if (!trimmed) {
+  const handleStartRenameDraft = useCallback((draftId: string) => {
+    setRenamingFolderId(null);
+    setRenamingDraftId(draftId);
+  }, []);
+
+  const handleSubmitDraftRename = useCallback(
+    async (draftId: string, name: string) => {
+      const trimmed = name.trim();
+      if (trimmed.length === 0) {
+        window.alert("Draft title cannot be empty.");
+        return;
+      }
+
+      const existing = drafts.find((draft) => draft.id === draftId);
+      if (existing && (existing.title ?? "").trim() === trimmed) {
+        setRenamingDraftId(null);
         return;
       }
 
@@ -487,9 +725,14 @@ export default function DraftsSidebar() {
       if (data) {
         setDrafts((prev) => prev.map((draft) => (draft.id === data.id ? data : draft)));
       }
+      setRenamingDraftId(null);
     },
-    [supabase],
+    [drafts, supabase],
   );
+
+  const handleCancelDraftRename = useCallback(() => {
+    setRenamingDraftId(null);
+  }, []);
 
   const handleDeleteDraft = useCallback(
     async (draftId: string) => {
@@ -509,6 +752,7 @@ export default function DraftsSidebar() {
       }
 
       setDrafts((prev) => prev.filter((draft) => draft.id !== draftId));
+      setRenamingDraftId((prev) => (prev === draftId ? null : prev));
     },
     [supabase],
   );
@@ -563,6 +807,8 @@ export default function DraftsSidebar() {
       [...prev, insertedFolder].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" })),
     );
     setExpandedFolders((prev) => (prev.includes(insertedFolder.id) ? prev : [...prev, insertedFolder.id]));
+    setRenamingDraftId(null);
+    setRenamingFolderId(insertedFolder.id);
   }, [canManageWorkspace, supabase]);
 
   const handleCreateDraft = useCallback(async () => {
@@ -659,10 +905,16 @@ export default function DraftsSidebar() {
                   expandedFolders={expandedFolders}
                   activeSlug={activeSlug}
                   onToggle={handleToggleFolder}
-                  onRenameFolder={handleRenameFolder}
+                  onRenameFolder={handleStartRenameFolder}
                   onDeleteFolder={handleDeleteFolder}
-                  onRenameDraft={handleRenameDraft}
+                  onRenameDraft={handleStartRenameDraft}
                   onDeleteDraft={handleDeleteDraft}
+                  renamingFolderId={renamingFolderId}
+                  renamingDraftId={renamingDraftId}
+                  onSubmitFolderRename={handleSubmitFolderRename}
+                  onSubmitDraftRename={handleSubmitDraftRename}
+                  onCancelFolderRename={handleCancelFolderRename}
+                  onCancelDraftRename={handleCancelDraftRename}
                 />
               ))
             )}


### PR DESCRIPTION
## Summary
- add inline rename inputs for folders and drafts in the write workspace sidebar
- synchronize renames with Supabase without relying on blocking prompts and auto-focus new folders
- ensure workspace nodes respect management permissions and clear rename state after deletions

## Testing
- npm run build *(fails: unable to download Libre Barcode 39 Text font in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ded07e911c832095eb14663394fc91