### PR TITLE
Simplify editor layout and relocate toolbar

### DIFF
--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { EditorContent, useEditor } from '@tiptap/react';
+import type { Editor as TiptapEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
@@ -9,18 +10,16 @@ import CharacterCount from '@tiptap/extension-character-count';
 import TextAlign from '@tiptap/extension-text-align';
 import type { JSONContent } from '@tiptap/core';
 
-import { useEditorTheme } from './EditorShell';
 import { FigureExtension } from './FigureExtension';
-import Toolbar from './Toolbar';
 import '@/styles/tiptap.css';
 
 type EditorProps = {
   readonly initial: JSONContent | null;
   readonly onChange: (json: JSONContent) => void;
+  readonly onReady?: (editor: TiptapEditor | null) => void;
 };
 
-export default function Editor({ initial, onChange }: EditorProps) {
-  const { accentColor } = useEditorTheme();
+export default function Editor({ initial, onChange, onReady }: EditorProps) {
   const editor = useEditor({
     immediatelyRender: false,
     extensions: [
@@ -43,28 +42,19 @@ export default function Editor({ initial, onChange }: EditorProps) {
     editor.commands.setContent(initial, false);
   }, [editor, initial]);
 
+  useEffect(() => {
+    onReady?.(editor ?? null);
+    return () => {
+      onReady?.(null);
+    };
+  }, [editor, onReady]);
+
   const characterCount = editor ? editor.storage.characterCount.characters() : 0;
 
   return (
     <div className="space-y-6">
-      <div className="lg:hidden">
-        <div className="rounded-xl border border-[var(--editor-toolbar-border)] bg-[var(--editor-toolbar-bg)] px-4 py-3 shadow-[var(--editor-shadow)]">
-          <Toolbar editor={editor} accent={accentColor} />
-        </div>
-      </div>
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_4.5rem]">
-        <div className="relative">
-          <div className="rounded-[2.5rem] border border-[var(--editor-border)] bg-[var(--editor-soft)] p-6 shadow-[var(--editor-shadow)]">
-            <div className="mx-auto w-full max-w-2xl rounded-[2rem] border border-[var(--editor-border)] bg-[var(--editor-card-bg)] px-8 py-10 shadow-[var(--editor-shadow)]">
-              <EditorContent editor={editor} className="tiptap" />
-            </div>
-          </div>
-        </div>
-        <aside className="hidden lg:block">
-          <div className="sticky top-28 rounded-2xl border border-[var(--editor-toolbar-border)] bg-[var(--editor-toolbar-bg)] p-3 shadow-[var(--editor-shadow)]">
-            <Toolbar editor={editor} accent={accentColor} orientation="vertical" />
-          </div>
-        </aside>
+      <div className="mx-auto w-full max-w-3xl">
+        <EditorContent editor={editor} className="tiptap" />
       </div>
       <div className="text-xs text-[color:var(--editor-muted)]">
         {characterCount} characters

--- a/components/editor/Toolbar.tsx
+++ b/components/editor/Toolbar.tsx
@@ -58,7 +58,13 @@ export default function Toolbar({
       onClick={onClick}
       disabled={disabled}
       aria-pressed={active}
-      className={`group flex items-center gap-2 rounded-md border border-[var(--editor-toolbar-border)] bg-transparent text-xs font-semibold uppercase tracking-[0.25em] text-[color:var(--editor-muted)] transition-colors disabled:cursor-not-allowed disabled:opacity-50 hover:border-[var(--accent)] hover:bg-[var(--editor-soft)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0 ${orientation === "vertical" ? "w-full px-3 py-2" : "px-3 py-2"}`}
+      aria-label={label}
+      title={label}
+      className={`group rounded-md border border-[var(--editor-toolbar-border)] text-[color:var(--editor-muted)] transition-colors disabled:cursor-not-allowed disabled:opacity-50 hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0 ${
+        orientation === "vertical"
+          ? "flex h-10 w-full items-center gap-2 px-3"
+          : "flex h-10 w-10 items-center justify-center"
+      }`}
       style={{
         borderColor: active ? accent : "var(--editor-toolbar-border)",
         color: active ? accent : undefined,
@@ -67,10 +73,10 @@ export default function Toolbar({
       }}
     >
       <Icon className="h-4 w-4" aria-hidden />
-      {orientation === "vertical" ? (
-        <span className="text-[10px] tracking-[0.3em]">{label}</span>
-      ) : (
-        <span className="sr-only">{label}</span>
+      {orientation === "vertical" && (
+        <span className="text-[10px] font-semibold uppercase tracking-[0.3em]">
+          {label}
+        </span>
       )}
     </button>
   );


### PR DESCRIPTION
## Summary
- remove the nested card backgrounds around the editor content so the document sits directly on the page
- expose the tiptap editor instance to the write view and relocate the formatting toolbar beside the save controls
- restyle toolbar buttons as icon-only actions with hover titles and remove the decorative icon beside the post title

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dedded42188320bcaf7a7832d595d3