### PR TITLE
Rework editor layout and toolbar positioning

### DIFF
--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -17,9 +17,10 @@ type EditorProps = {
   readonly initial: JSONContent | null;
   readonly onChange: (json: JSONContent) => void;
   readonly onReady?: (editor: TiptapEditor | null) => void;
+  readonly onCharacterCountChange?: (count: number) => void;
 };
 
-export default function Editor({ initial, onChange, onReady }: EditorProps) {
+export default function Editor({ initial, onChange, onReady, onCharacterCountChange }: EditorProps) {
   const editor = useEditor({
     immediatelyRender: false,
     extensions: [
@@ -34,31 +35,29 @@ export default function Editor({ initial, onChange, onReady }: EditorProps) {
     autofocus: false,
     onUpdate({ editor }) {
       onChange(editor.getJSON());
+      onCharacterCountChange?.(editor.storage.characterCount.characters());
     },
   });
 
   useEffect(() => {
     if (!editor || !initial) return;
     editor.commands.setContent(initial, false);
-  }, [editor, initial]);
+    onCharacterCountChange?.(editor.storage.characterCount.characters());
+  }, [editor, initial, onCharacterCountChange]);
 
   useEffect(() => {
     onReady?.(editor ?? null);
+    if (editor) {
+      onCharacterCountChange?.(editor.storage.characterCount.characters());
+    }
     return () => {
       onReady?.(null);
     };
-  }, [editor, onReady]);
-
-  const characterCount = editor ? editor.storage.characterCount.characters() : 0;
+  }, [editor, onCharacterCountChange, onReady]);
 
   return (
-    <div className="space-y-6">
-      <div className="mx-auto w-full max-w-3xl">
-        <EditorContent editor={editor} className="tiptap" />
-      </div>
-      <div className="text-xs text-[color:var(--editor-muted)]">
-        {characterCount} characters
-      </div>
+    <div className="mx-auto w-full max-w-3xl">
+      <EditorContent editor={editor} className="tiptap" />
     </div>
   );
 }

--- a/components/editor/SaveIndicator.tsx
+++ b/components/editor/SaveIndicator.tsx
@@ -24,7 +24,7 @@ export default function SaveIndicator({ state }: SaveIndicatorProps) {
 
   return (
     <span
-      className="text-sm transition-colors"
+      className="text-[10px] uppercase tracking-[0.28em] transition-colors"
       style={{
         color:
           state === "saved"


### PR DESCRIPTION
## Summary
- remove the background container around the editor title area and introduce character count tracking at the page level
- float the toolbar along the right edge with a mobile-friendly fallback and relocate save feedback beneath the editor content
- add a sticky bottom action bar that surfaces the slug alongside Snapshot, Save Draft, and Publish controls

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68def36bb7fc83208725059559b8a0ce