### PR TITLE
Fix editor toolbar and footer layout

### DIFF
--- a/app/write/[slug]/page.tsx
+++ b/app/write/[slug]/page.tsx
@@ -247,21 +247,6 @@ export default function WriteSlugPage() {
             />
           </div>
           <div className="flex flex-col items-start gap-2 text-xs font-semibold uppercase tracking-[0.32em] text-[color:var(--editor-muted)] sm:flex-row sm:items-center sm:gap-4">
-            <span
-              className="inline-flex items-center gap-2 rounded-full border px-3 py-1"
-              style={
-                isPublished
-                  ? { borderColor: accentColor, color: accentColor }
-                  : undefined
-              }
-            >
-              {isPublished ? (
-                <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
-              ) : (
-                <FilePenLine className="h-3.5 w-3.5" aria-hidden />
-              )}
-              {statusText}
-            </span>
             {publishedLabel && (
               <span className="inline-flex items-center gap-2 normal-case tracking-normal">
                 <Clock3 className="h-3.5 w-3.5" aria-hidden />
@@ -297,11 +282,28 @@ export default function WriteSlugPage() {
       <div className="mx-auto w-full max-w-4xl px-5">
         <div className="flex flex-wrap items-center justify-between gap-3 text-[10px] uppercase tracking-[0.28em] text-[color:var(--editor-muted)] opacity-70">
           <span>{characterCount.toLocaleString()} characters</span>
-          <SaveIndicator state={saving} />
+          <div className="flex flex-wrap items-center justify-end gap-3">
+            <SaveIndicator state={saving} />
+            <span
+              className="inline-flex items-center gap-2 rounded-full border px-3 py-1"
+              style={
+                isPublished
+                  ? { borderColor: accentColor, color: accentColor }
+                  : undefined
+              }
+            >
+              {isPublished ? (
+                <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+              ) : (
+                <FilePenLine className="h-3.5 w-3.5" aria-hidden />
+              )}
+              {statusText}
+            </span>
+          </div>
         </div>
       </div>
       <nav
-        className="sticky bottom-0 z-20 border-t border-[var(--editor-border)] px-5 py-4 backdrop-blur"
+        className="fixed inset-x-0 bottom-0 z-20 border-t border-[var(--editor-border)] px-5 py-4 backdrop-blur"
         style={{ backgroundColor: "var(--editor-nav-bg)" }}
       >
         <div className="mx-auto flex w-full max-w-4xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/components/editor/Toolbar.tsx
+++ b/components/editor/Toolbar.tsx
@@ -62,7 +62,7 @@ export default function Toolbar({
       title={label}
       className={`group rounded-md border border-[var(--editor-toolbar-border)] text-[color:var(--editor-muted)] transition-colors disabled:cursor-not-allowed disabled:opacity-50 hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0 ${
         orientation === "vertical"
-          ? "flex h-10 w-full items-center gap-2 px-3"
+          ? "flex h-10 w-full items-center justify-center"
           : "flex h-10 w-10 items-center justify-center"
       }`}
       style={{
@@ -73,11 +73,6 @@ export default function Toolbar({
       }}
     >
       <Icon className="h-4 w-4" aria-hidden />
-      {orientation === "vertical" && (
-        <span className="text-[10px] font-semibold uppercase tracking-[0.3em]">
-          {label}
-        </span>
-      )}
     </button>
   );
 


### PR DESCRIPTION
## Summary
- keep the editor action bar fixed to the bottom of the viewport
- relocate the status badge beside the character count line and align it to the right
- remove text labels from toolbar buttons while centering their icons

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68defcc00694832091e12ce52b6d5b80