### PR TITLE
Tighten editor toolbar layout and center bottom navigation

### DIFF
--- a/app/write/[slug]/page.tsx
+++ b/app/write/[slug]/page.tsx
@@ -268,7 +268,7 @@ export default function WriteSlugPage() {
       {editorInstance && (
         <>
           <div className="pointer-events-none">
-            <div className="pointer-events-auto fixed right-6 top-1/3 z-30 hidden xl:flex">
+            <div className="pointer-events-auto fixed right-6 top-1/2 z-30 hidden -translate-y-1/2 xl:flex">
               <Toolbar editor={editorInstance} accent={accentColor} orientation="vertical" />
             </div>
           </div>
@@ -284,29 +284,29 @@ export default function WriteSlugPage() {
           <span>{characterCount.toLocaleString()} characters</span>
           <div className="flex flex-wrap items-center justify-end gap-3">
             <SaveIndicator state={saving} />
-            <span
-              className="inline-flex items-center gap-2 rounded-full border px-3 py-1"
-              style={
-                isPublished
-                  ? { borderColor: accentColor, color: accentColor }
-                  : undefined
-              }
-            >
-              {isPublished ? (
-                <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
-              ) : (
-                <FilePenLine className="h-3.5 w-3.5" aria-hidden />
-              )}
-              {statusText}
-            </span>
+            {saving === "saving" && (
+              <span
+                className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 ${
+                  isPublished
+                    ? "border-[var(--accent)] text-[color:var(--accent)]"
+                    : "border-[var(--editor-border)] text-[color:var(--editor-muted)]"
+                }`}
+              >
+                {isPublished ? (
+                  <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+                ) : (
+                  <FilePenLine className="h-3.5 w-3.5" aria-hidden />
+                )}
+                {statusText}
+              </span>
+            )}
           </div>
         </div>
       </div>
       <nav
-        className="fixed inset-x-0 bottom-0 z-20 border-t border-[var(--editor-border)] px-5 py-4 backdrop-blur"
-        style={{ backgroundColor: "var(--editor-nav-bg)" }}
+        className="fixed bottom-0 left-1/2 z-20 w-full max-w-4xl -translate-x-1/2 border-t border-[var(--editor-border)] bg-[color:var(--editor-nav-bg)] px-5 py-4 backdrop-blur"
       >
-        <div className="mx-auto flex w-full max-w-4xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="mx-auto flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.28em] text-[color:var(--editor-muted)]">
             <span className="inline-flex items-center gap-2">
               <Link2 className="h-3.5 w-3.5" aria-hidden />

--- a/components/editor/SaveIndicator.tsx
+++ b/components/editor/SaveIndicator.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useEditorTheme } from "./EditorShell";
-
 type SaveState = "idle" | "saving" | "saved" | "error";
 
 type SaveIndicatorProps = {
@@ -9,32 +7,13 @@ type SaveIndicatorProps = {
 };
 
 export default function SaveIndicator({ state }: SaveIndicatorProps) {
-  const { accentColor } = useEditorTheme();
-
-  const text =
-    state === "saving"
-      ? "Saving…"
-      : state === "saved"
-        ? "Saved"
-        : state === "error"
-          ? "Error"
-          : "";
-
-  if (!text) return null;
+  if (state !== "saving") return null;
 
   return (
     <span
-      className="text-[10px] uppercase tracking-[0.28em] transition-colors"
-      style={{
-        color:
-          state === "saved"
-            ? accentColor
-            : state === "error"
-              ? "#f87171"
-              : "var(--editor-muted)",
-      }}
+      className="text-[10px] uppercase tracking-[0.28em] text-[color:var(--editor-muted)]"
     >
-      {text}
+      Saving…
     </span>
   );
 }

--- a/components/editor/Toolbar.tsx
+++ b/components/editor/Toolbar.tsx
@@ -60,10 +60,10 @@ export default function Toolbar({
       aria-pressed={active}
       aria-label={label}
       title={label}
-      className={`group rounded-md border border-[var(--editor-toolbar-border)] text-[color:var(--editor-muted)] transition-colors disabled:cursor-not-allowed disabled:opacity-50 hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0 ${
+      className={`group flex items-center justify-center rounded-md border border-[var(--editor-toolbar-border)] px-3 py-2 text-[color:var(--editor-muted)] transition-colors disabled:cursor-not-allowed disabled:opacity-50 hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0 ${
         orientation === "vertical"
-          ? "flex h-10 w-full items-center justify-center"
-          : "flex h-10 w-10 items-center justify-center"
+          ? "w-12"
+          : "min-w-[2.75rem]"
       }`}
       style={{
         borderColor: active ? accent : "var(--editor-toolbar-border)",
@@ -102,8 +102,8 @@ export default function Toolbar({
     <div
       className={
         orientation === "vertical"
-          ? "flex flex-col gap-2"
-          : "flex flex-wrap items-center gap-2"
+          ? "flex flex-col items-center gap-2"
+          : "flex flex-wrap items-center justify-center gap-2"
       }
     >
       {button({


### PR DESCRIPTION
## Summary
- expand padding on editor toolbar buttons and center the controls within their container
- hide the save status chips unless a save is in progress to keep the footer tidy
- align the bottom navigation with the document width and remove inline styling for the background

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68deff30fe888320ad215349447a97fe