### PR TITLE
Prevent editor cursor from jumping to end

### DIFF
--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { EditorContent, useEditor } from '@tiptap/react';
 import type { Editor as TiptapEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -39,8 +39,30 @@ export default function Editor({ initial, onChange, onReady, onCharacterCountCha
     },
   });
 
+  const lastInitial = useRef<string | null>(null);
+
   useEffect(() => {
-    if (!editor || !initial) return;
+    if (!editor) return;
+
+    if (initial == null) {
+      lastInitial.current = null;
+      return;
+    }
+
+    const nextInitial = JSON.stringify(initial);
+
+    if (lastInitial.current === nextInitial) {
+      return;
+    }
+
+    lastInitial.current = nextInitial;
+
+    const currentContent = JSON.stringify(editor.getJSON());
+
+    if (currentContent === nextInitial) {
+      return;
+    }
+
     editor.commands.setContent(initial, false);
     onCharacterCountChange?.(editor.storage.characterCount.characters());
   }, [editor, initial, onCharacterCountChange]);


### PR DESCRIPTION
## Summary
- guard the editor content reset logic so it only runs when the incoming initial value actually changes
- avoid resetting the Tiptap selection on every keystroke to keep the caret in place

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df0f21c154832083531ff6aee01cbd