### PR TITLE
Fix toolbar buttons not updating active state

### DIFF
--- a/components/editor/Toolbar.tsx
+++ b/components/editor/Toolbar.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { useRef, type ChangeEvent } from "react";
+import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import type { Editor } from "@tiptap/react";
 import type { LucideIcon } from "lucide-react";
 import {
@@ -37,6 +37,25 @@ export default function Toolbar({
 }: ToolbarProps) {
   const supabase = createClient();
   const fileRef = useRef<HTMLInputElement | null>(null);
+  const [, setRenderCount] = useState(0);
+
+  useEffect(() => {
+    if (!editor) return;
+
+    const forceUpdate = () => setRenderCount((count) => count + 1);
+
+    editor.on("transaction", forceUpdate);
+    editor.on("selectionUpdate", forceUpdate);
+    editor.on("focus", forceUpdate);
+    editor.on("blur", forceUpdate);
+
+    return () => {
+      editor.off("transaction", forceUpdate);
+      editor.off("selectionUpdate", forceUpdate);
+      editor.off("focus", forceUpdate);
+      editor.off("blur", forceUpdate);
+    };
+  }, [editor]);
 
   if (!editor) return null;
 


### PR DESCRIPTION
## Summary
- force the toolbar to re-render whenever the TipTap editor dispatches transactions or selection updates
- ensure active button styles update immediately after toggling formatting

## Testing
- npm run lint *(fails: script missing)*

------
https://chatgpt.com/codex/tasks/task_e_68df10859a648320938b591cc4cadfda