### PR TITLE
Implement glowing draft actions with modal confirmation

### DIFF
--- a/components/editor/DraftsSidebar.tsx
+++ b/components/editor/DraftsSidebar.tsx
@@ -4,16 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 
-import {
-  ChevronDown,
-  ChevronRight,
-  FilePlus,
-  FileText,
-  Folder,
-  FolderOpen,
-  FolderPlus,
-  Folders,
-} from "lucide-react";
+import { ChevronDown, ChevronRight, FilePlus, Folder, FolderOpen, FolderPlus, Folders } from "lucide-react";
 
 import { createClient } from "@/lib/supabase/client";
 
@@ -87,7 +78,7 @@ type TreeNodeItemProps = {
 
 const UNFILED_FOLDER_ID = "workspace-unfiled";
 
-const INDENT_STEP_REM = 0.75;
+const INDENT_STEP_REM = 1.25;
 
 const toTitle = (title: string | null) => (title && title.trim().length > 0 ? title : "Untitled draft");
 
@@ -112,7 +103,7 @@ function TreeNodeItem({
   onCancelFolderRename,
   onCancelDraftRename,
 }: TreeNodeItemProps) {
-  const indentStyle = { paddingLeft: `${Math.max(0, depth - 1) * INDENT_STEP_REM}rem` };
+  const indentStyle = { paddingLeft: `${Math.max(0, depth) * INDENT_STEP_REM}rem` };
   const [folderName, setFolderName] = useState(node.type === "folder" ? node.name : "");
   const [draftName, setDraftName] = useState(node.type === "draft" ? node.name : "");
   const [folderSubmitting, setFolderSubmitting] = useState(false);
@@ -367,12 +358,7 @@ function TreeNodeItem({
           }}
         >
           {isRenaming ? (
-            <form onSubmit={handleSubmit} className="flex min-w-0 flex-1 items-center gap-2" spellCheck={false}>
-              <FileText
-                aria-hidden
-                className="h-4 w-4 shrink-0 text-[color:var(--editor-muted)]"
-                style={isActive ? { color: accentColor } : undefined}
-              />
+            <form onSubmit={handleSubmit} className="flex min-w-0 flex-1 items-center" spellCheck={false}>
               <input
                 ref={draftInputRef}
                 value={draftName}
@@ -387,14 +373,9 @@ function TreeNodeItem({
           ) : (
             <Link
               href={`/write/${node.slug}`}
-              className="flex min-w-0 flex-1 items-center gap-2"
+              className="flex min-w-0 flex-1 items-center"
               title={formatUpdatedAt(node.updatedAt)}
             >
-              <FileText
-                aria-hidden
-                className="h-4 w-4 shrink-0 text-[color:var(--editor-muted)] transition-colors group-hover:text-[var(--accent)]"
-                style={isActive ? { color: accentColor } : undefined}
-              />
               <span
                 className="truncate group-hover:text-[var(--accent)]"
                 style={isActive ? { color: accentColor } : undefined}

--- a/components/editor/ItemActionMenu.tsx
+++ b/components/editor/ItemActionMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useId, useState } from "react";
 import { Pencil, Trash2 } from "lucide-react";
 
 type ItemActionMenuProps = {
@@ -16,6 +16,10 @@ export default function ItemActionMenu({
   onRename,
   onDelete,
 }: ItemActionMenuProps) {
+  const confirmTitleId = useId();
+  const confirmDescriptionId = useId();
+  const [showConfirm, setShowConfirm] = useState(false);
+
   const handleRename = useCallback(() => {
     onRename?.();
   }, [onRename]);
@@ -24,37 +28,82 @@ export default function ItemActionMenu({
     if (!onDelete) {
       return;
     }
-    const confirmed = window.confirm("Are you sure you want to delete this item?");
-    if (confirmed) {
-      onDelete();
+    setShowConfirm(true);
+  }, [onDelete]);
+
+  const handleCancelDelete = useCallback(() => {
+    setShowConfirm(false);
+  }, []);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (!onDelete) {
+      return;
     }
+    onDelete();
+    setShowConfirm(false);
   }, [onDelete]);
 
   return (
-    <div
-      className={`flex items-center gap-1 ${className ?? ""}`}
-      aria-label={ariaLabel}
-      role="group"
-    >
+    <div className={`flex items-center gap-1 ${className ?? ""}`} aria-label={ariaLabel} role="group">
       {onRename && (
         <button
           type="button"
           onClick={handleRename}
-          className="flex h-6 w-6 items-center justify-center rounded-sm text-[color:var(--editor-muted)] transition-colors hover:text-[var(--editor-page-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+          className="flex h-6 w-6 items-center justify-center rounded-sm text-[color:var(--editor-muted)] transition-all hover:text-yellow-400 hover:shadow-[0_0_0.75rem_rgba(250,204,21,0.65)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
           aria-label="Rename"
         >
           <Pencil className="h-4 w-4" aria-hidden />
         </button>
       )}
       {onDelete && (
-        <button
-          type="button"
-          onClick={handleDelete}
-          className="flex h-6 w-6 items-center justify-center rounded-sm text-[color:var(--editor-muted)] transition-colors hover:text-[color:var(--editor-danger, #d92c20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
-          aria-label="Delete"
-        >
-          <Trash2 className="h-4 w-4" aria-hidden />
-        </button>
+        <>
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="flex h-6 w-6 items-center justify-center rounded-sm text-[color:var(--editor-muted)] transition-all hover:text-[color:var(--editor-danger, #d92c20)] hover:shadow-[0_0_0.75rem_rgba(217,44,32,0.55)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            aria-label="Delete"
+          >
+            <Trash2 className="h-4 w-4" aria-hidden />
+          </button>
+          {showConfirm && (
+            <div
+              className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby={confirmTitleId}
+              aria-describedby={confirmDescriptionId}
+              onClick={handleCancelDelete}
+            >
+              <div
+                className="w-full max-w-sm rounded-lg border border-[var(--editor-border)] bg-[color:var(--editor-surface,#ffffff)] p-6 text-[color:var(--editor-page-text)] shadow-xl"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <h2 id={confirmTitleId} className="text-lg font-semibold">
+                  Delete item
+                </h2>
+                <p id={confirmDescriptionId} className="mt-2 text-sm text-[color:var(--editor-muted)]">
+                  Are you sure you want to delete this item? This action cannot be undone.
+                </p>
+                <div className="mt-6 flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={handleCancelDelete}
+                    className="rounded-md border border-[var(--editor-border)] px-3 py-1.5 text-sm font-medium text-[color:var(--editor-page-text)] transition-colors hover:bg-[var(--editor-soft)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleConfirmDelete}
+                    className="rounded-md bg-[color:var(--editor-danger, #d92c20)] px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-[color:var(--editor-danger-strong,#b81f16)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add a custom confirmation modal to the draft action menu and enhance hover states for the edit/delete icons
- remove the file icon from draft entries and increase their indentation in the drafts sidebar for clearer hierarchy

## Testing
- npm run build *(fails: unable to download Google Font due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68df1a0e718c8320b2cc8138363fed5b