### PR TITLE
Adjust delete modal styling and spacing

### DIFF
--- a/app/write/[slug]/page.tsx
+++ b/app/write/[slug]/page.tsx
@@ -207,7 +207,7 @@ export default function WriteSlugPage() {
   const canSaveDraft = Boolean(postId && content);
 
   return (
-    <div className="space-y-8 pb-32">
+    <div className="space-y-6 pb-32">
       <div className="sticky top-0 z-20 bg-[color:var(--editor-page-bg)]/90 backdrop-blur supports-[backdrop-filter]:bg-[color:var(--editor-page-bg)]/80">
         <div className="mx-auto w-full max-w-4xl space-y-3 px-5 py-5">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -79,7 +79,7 @@ export default function Editor({ initial, onChange, onReady, onCharacterCountCha
 
   return (
     <div className="mx-auto w-full max-w-4xl px-5">
-      <div className="rounded-lg bg-[color:var(--editor-page-bg)] px-6 py-8">
+      <div className="rounded-lg bg-[color:var(--editor-page-bg)] px-6 py-6">
         <EditorContent editor={editor} className="tiptap" />
       </div>
     </div>

--- a/components/editor/EditorShell.module.css
+++ b/components/editor/EditorShell.module.css
@@ -17,6 +17,8 @@
   --editor-input-bg: rgba(11, 11, 18, 0.82);
   --editor-input-border: rgba(255, 255, 255, 0.14);
   --editor-card-bg: rgba(255, 255, 255, 0.05);
+  --editor-danger: #ff3b30;
+  --editor-danger-strong: #c81e14;
   --editor-shadow: 0 28px 60px -42px rgba(0, 0, 0, 0.78);
   --editor-account-bg: rgba(255, 255, 255, 0.05);
   background-color: var(--editor-page-bg);
@@ -38,6 +40,8 @@
   --editor-input-bg: rgba(255, 255, 255, 0.98);
   --editor-input-border: rgba(35, 25, 48, 0.18);
   --editor-card-bg: rgba(255, 255, 255, 0.9);
+  --editor-danger: #ff3b30;
+  --editor-danger-strong: #c81e14;
   --editor-shadow: 0 32px 70px -48px rgba(42, 28, 58, 0.32);
   --editor-account-bg: rgba(255, 255, 255, 0.9);
   background-color: var(--editor-page-bg);

--- a/components/editor/ItemActionMenu.tsx
+++ b/components/editor/ItemActionMenu.tsx
@@ -60,7 +60,7 @@ export default function ItemActionMenu({
           <button
             type="button"
             onClick={handleDelete}
-            className="flex h-6 w-6 items-center justify-center rounded-sm text-[color:var(--editor-muted)] transition-colors hover:text-[color:var(--editor-danger, #d92c20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            className="flex h-6 w-6 items-center justify-center rounded-sm text-[color:var(--editor-muted)] transition-colors hover:text-[color:var(--editor-danger)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
             aria-label="Delete"
           >
             <Trash2 className="h-4 w-4" aria-hidden />
@@ -98,7 +98,7 @@ export default function ItemActionMenu({
                   <button
                     type="button"
                     onClick={handleConfirmDelete}
-                    className="rounded-md bg-[color:var(--editor-danger, #d92c20)] px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-[color:var(--editor-danger-strong,#b81f16)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+                    className="rounded-md border border-[color:var(--editor-danger)] px-3 py-1.5 text-sm font-semibold text-[color:var(--editor-danger)] transition-colors hover:bg-[color:color-mix(in_srgb,var(--editor-danger)_15%,transparent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
                   >
                     Delete
                   </button>


### PR DESCRIPTION
## Summary
- color the delete icon hover state and modal action text with a new bright red danger token
- add shared danger color variables for both editor themes to keep light and dark modals consistent
- reduce the vertical spacing between the title header and the document canvas

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68df1ec297d88320a164044cc26884cc