### PR TITLE
Show draft listing on writer landing and streamline deletion

### DIFF
--- a/app/write/page.tsx
+++ b/app/write/page.tsx
@@ -1,49 +1,277 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import type { JSONContent } from "@tiptap/core";
 
 import { createClient } from "@/lib/supabase/client";
 
+type PostStatus = "draft" | "published";
+
+type SupabasePost = {
+  readonly id: string;
+  readonly title: string | null;
+  readonly slug: string;
+  readonly status: PostStatus;
+  readonly updated_at: string | null;
+  readonly created_at: string | null;
+  readonly excerpt?: string | null;
+  readonly summary?: string | null;
+  readonly content_json?: JSONContent | null;
+};
+
+type PostCard = {
+  readonly id: string;
+  readonly title: string;
+  readonly slug: string;
+  readonly status: PostStatus;
+  readonly updatedAt: string | null;
+  readonly excerpt: string;
+};
+
+const DEFAULT_EXCERPT = "No summary yet. Open the post to start writing.";
+
+function collectText(node: JSONContent | null | undefined): string {
+  if (!node) return "";
+  if (typeof node.text === "string") {
+    return node.text;
+  }
+  if (!Array.isArray(node.content)) {
+    return "";
+  }
+  return node.content.map((child) => collectText(child as JSONContent)).join(" ");
+}
+
+function toExcerpt(post: SupabasePost): string {
+  const fallback = post.excerpt ?? post.summary ?? "";
+  const plain = fallback || collectText(post.content_json ?? null);
+  if (!plain) {
+    return DEFAULT_EXCERPT;
+  }
+  const trimmed = plain.replace(/\s+/g, " ").trim();
+  if (!trimmed) {
+    return DEFAULT_EXCERPT;
+  }
+  return trimmed.length > 160 ? `${trimmed.slice(0, 157).trimEnd()}…` : trimmed;
+}
+
+function formatUpdatedAt(updatedAt: string | null): string {
+  if (!updatedAt) return "Never opened";
+  const date = new Date(updatedAt);
+  if (Number.isNaN(date.getTime())) return "Never opened";
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
 export default function WriteIndex() {
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
   const router = useRouter();
+  const isMounted = useRef(true);
+  const [posts, setPosts] = useState<PostCard[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
 
   useEffect(() => {
-    (async () => {
-      const title = "Untitled";
-      const slug = `untitled-${Math.random().toString(36).slice(2, 8)}`;
-      const { data: auth } = await supabase.auth.getUser();
-      const user = auth.user;
-      if (!user) {
-        alert("Sign in first");
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  const loadPosts = useCallback(async () => {
+    if (!isMounted.current) return;
+    setLoading(true);
+    setError(null);
+
+    const { data: auth, error: authError } = await supabase.auth.getUser();
+    const user = auth?.user ?? null;
+    if (authError || !user) {
+      if (!isMounted.current) return;
+      setError("Sign in first.");
+      setLoading(false);
+      return;
+    }
+
+    const { data, error } = await supabase
+      .from("posts")
+      .select("id,title,slug,status,updated_at,created_at,excerpt,summary,content_json")
+      .eq("author_id", user.id)
+      .eq("is_deleted", false)
+      .order("updated_at", { ascending: false })
+      .limit(100)
+      .returns<SupabasePost[]>();
+
+    if (!isMounted.current) return;
+
+    if (error) {
+      setError(error.message);
+      setPosts([]);
+      setLoading(false);
+      return;
+    }
+
+    const normalized = (data ?? []).map((post) => ({
+      id: post.id,
+      title: (post.title ?? "Untitled").trim() || "Untitled",
+      slug: post.slug,
+      status: post.status,
+      updatedAt: post.updated_at ?? post.created_at ?? null,
+      excerpt: toExcerpt(post),
+    } satisfies PostCard));
+
+    setPosts(normalized);
+    setLoading(false);
+  }, [supabase]);
+
+  useEffect(() => {
+    void loadPosts();
+  }, [loadPosts]);
+
+  useEffect(() => {
+    const handleRefresh = () => {
+      void loadPosts();
+    };
+    const handleDraftUpdated: EventListener = (event) => {
+      const detail = (event as CustomEvent<Partial<PostCard> & { id: string }>).detail;
+      if (!detail || !detail.id) {
         return;
       }
+      setPosts((prev) =>
+        prev.map((post) =>
+          post.id === detail.id
+            ? {
+                ...post,
+                title: typeof detail.title === "string" && detail.title.trim().length > 0 ? detail.title : post.title,
+                slug: typeof detail.slug === "string" && detail.slug.length > 0 ? detail.slug : post.slug,
+              }
+            : post,
+        ),
+      );
+    };
 
-      const { data, error } = await supabase
-        .from("posts")
-        .insert({
-          author_id: user.id,
-          title,
-          slug,
-          status: "draft",
-          content_json: { type: "doc", content: [{ type: "paragraph" }] },
-        })
-        .select("slug")
-        .single();
+    window.addEventListener("editor:refresh-drafts", handleRefresh);
+    window.addEventListener("editor:draft-updated", handleDraftUpdated);
+    return () => {
+      window.removeEventListener("editor:refresh-drafts", handleRefresh);
+      window.removeEventListener("editor:draft-updated", handleDraftUpdated);
+    };
+  }, [loadPosts]);
 
-      if (error) {
-        alert(error.message);
-        return;
+  const handleCreateDraft = useCallback(async () => {
+    if (creating) return;
+    setCreating(true);
+    setError(null);
+
+    const { data: auth, error: authError } = await supabase.auth.getUser();
+    const user = auth?.user ?? null;
+    if (authError || !user) {
+      if (isMounted.current) {
+        setError("Sign in first.");
+        setCreating(false);
       }
+      return;
+    }
 
-      router.replace(`/write/${data.slug}`);
-    })();
-  }, [router, supabase]);
+    const title = "Untitled";
+    const slug = `untitled-${Math.random().toString(36).slice(2, 8)}`;
+
+    const { data, error } = await supabase
+      .from("posts")
+      .insert({
+        author_id: user.id,
+        title,
+        slug,
+        status: "draft",
+        content_json: { type: "doc", content: [{ type: "paragraph" }] },
+      })
+      .select("slug")
+      .single();
+
+    if (!isMounted.current) {
+      return;
+    }
+
+    if (error || !data) {
+      setError(error?.message ?? "Unable to create draft.");
+      setCreating(false);
+      return;
+    }
+
+    router.push(`/write/${data.slug}`);
+  }, [creating, router, supabase]);
+
+  const handleRetry = useCallback(() => {
+    void loadPosts();
+  }, [loadPosts]);
 
   return (
-    <div className="rounded-2xl border border-[var(--editor-border)] bg-[var(--editor-surface)] px-6 py-10 text-sm text-[color:var(--editor-muted)] shadow-[var(--editor-shadow)]">
-      Creating draft…
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-[color:var(--editor-page-text)]">Your posts</h1>
+          <p className="text-sm text-[color:var(--editor-muted)]">
+            Select a draft to continue writing or create something new.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleCreateDraft}
+          disabled={creating}
+          className="inline-flex h-10 items-center justify-center rounded-lg border border-[var(--accent)] px-4 text-sm font-medium text-[color:var(--accent)] transition-colors hover:bg-[color:color-mix(in_srgb,var(--accent)_12%,transparent)] disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {creating ? "Creating…" : "New draft"}
+        </button>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-[color:var(--editor-danger)] bg-[color:color-mix(in_srgb,var(--editor-danger)_10%,transparent)] px-4 py-3 text-sm text-[color:var(--editor-danger)]">
+          <div className="flex items-center justify-between gap-4">
+            <span>{error}</span>
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="text-xs font-medium underline underline-offset-2 hover:text-[color:color-mix(in_srgb,var(--editor-danger)_65%,var(--editor-page-text)_35%)]"
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="rounded-2xl border border-[var(--editor-border)] bg-[var(--editor-surface)] px-6 py-10 text-sm text-[color:var(--editor-muted)] shadow-[var(--editor-shadow)]">
+          Loading drafts…
+        </div>
+      ) : posts.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-[var(--editor-border)] bg-[var(--editor-surface)] px-6 py-16 text-center text-sm text-[color:var(--editor-muted)] shadow-[var(--editor-shadow)]">
+          You haven&apos;t created any drafts yet. Start by clicking <span className="font-medium text-[color:var(--accent)]">New draft</span>.
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {posts.map((post) => (
+            <button
+              key={post.id}
+              type="button"
+              onClick={() => router.push(`/write/${post.slug}`)}
+              className="group flex h-full flex-col rounded-2xl border border-[var(--editor-border)] bg-[var(--editor-surface)] p-5 text-left shadow-[var(--editor-shadow)] transition-colors hover:border-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-0"
+            >
+              <div className="flex items-center justify-between text-xs uppercase tracking-[0.25em] text-[color:var(--editor-muted)]">
+                <span>{post.status === "published" ? "Published" : "Draft"}</span>
+                <span>{formatUpdatedAt(post.updatedAt)}</span>
+              </div>
+              <h2 className="mt-4 text-lg font-semibold text-[color:var(--editor-page-text)] transition-colors group-hover:text-[var(--accent)]">
+                {post.title}
+              </h2>
+              <p className="mt-3 text-sm text-[color:var(--editor-muted)]">{post.excerpt}</p>
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/editor/DraftsSidebar.tsx
+++ b/components/editor/DraftsSidebar.tsx
@@ -680,11 +680,6 @@ export default function DraftsSidebar() {
 
   const handleDeleteFolder = useCallback(
     async (folderId: string) => {
-      const confirmed = window.confirm("Delete this folder? Drafts will be moved to Unfiled.");
-      if (!confirmed) {
-        return;
-      }
-
       const { error } = await supabase.from("folders").delete().eq("id", folderId);
       if (error) {
         window.alert(`Unable to delete folder: ${error.message}`);
@@ -746,11 +741,6 @@ export default function DraftsSidebar() {
 
   const handleDeleteDraft = useCallback(
     async (draftId: string) => {
-      const confirmed = window.confirm("Delete this draft?");
-      if (!confirmed) {
-        return;
-      }
-
       const { error } = await supabase
         .from("posts")
         .update({ is_deleted: true })
@@ -763,6 +753,7 @@ export default function DraftsSidebar() {
 
       setDrafts((prev) => prev.filter((draft) => draft.id !== draftId));
       setRenamingDraftId((prev) => (prev === draftId ? null : prev));
+      window.dispatchEvent(new Event("editor:refresh-drafts"));
     },
     [supabase],
   );


### PR DESCRIPTION
## Summary
- replace the /write landing view with a draft gallery that loads the signed-in author's posts and lets them create new drafts on demand
- add client-side handling for draft updates and errors so cards stay in sync with editor events
- remove redundant browser confirms for draft and folder deletion, relying on the existing modal and refreshing views after removal

## Testing
- npm run build *(fails: Google Fonts download is blocked in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df2944a6d88320a7b3d19db9b8460e