### PR TITLE
Replace summary usage with excerpt fallbacks

### DIFF
--- a/app/home/HomeClient.tsx
+++ b/app/home/HomeClient.tsx
@@ -19,7 +19,6 @@ type SupabasePost = {
   readonly title: string | null;
   readonly slug: string;
   readonly excerpt?: string | null;
-  readonly summary?: string | null;
   readonly content_json?: JSONContent | null;
   readonly category?: string | null;
   readonly tags?: string[] | null;
@@ -56,7 +55,7 @@ function normalizePost(post: SupabasePost): PostCardPost {
   return {
     title: post.title ?? "Untitled",
     slug: post.slug,
-    excerpt: extractExcerpt(post.content_json ?? null, post.excerpt ?? post.summary ?? null),
+    excerpt: extractExcerpt(post.content_json ?? null, post.excerpt ?? null),
     category: post.category ?? undefined,
     tags: post.tags ?? undefined,
     readingTime: post.readingTime ?? post.reading_time ?? undefined,

--- a/app/write/page.tsx
+++ b/app/write/page.tsx
@@ -16,7 +16,6 @@ type SupabasePost = {
   readonly updated_at: string | null;
   readonly created_at: string | null;
   readonly excerpt?: string | null;
-  readonly summary?: string | null;
   readonly content_json?: JSONContent | null;
 };
 
@@ -43,7 +42,7 @@ function collectText(node: JSONContent | null | undefined): string {
 }
 
 function toExcerpt(post: SupabasePost): string {
-  const fallback = post.excerpt ?? post.summary ?? "";
+  const fallback = post.excerpt ?? "";
   const plain = fallback || collectText(post.content_json ?? null);
   if (!plain) {
     return DEFAULT_EXCERPT;
@@ -99,7 +98,7 @@ export default function WriteIndex() {
 
     const { data, error } = await supabase
       .from("posts")
-      .select("id,title,slug,status,updated_at,created_at,excerpt,summary,content_json")
+      .select("id,title,slug,status,updated_at,created_at,excerpt,content_json")
       .eq("author_id", user.id)
       .eq("is_deleted", false)
       .order("updated_at", { ascending: false })

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -2,7 +2,6 @@ export type PostCardPost = {
   readonly title: string;
   readonly slug: string;
   readonly excerpt?: string | null;
-  readonly summary?: string | null;
   readonly category?: string | null;
   readonly tags?: readonly string[] | null;
   readonly readingTime?: string | null;
@@ -70,7 +69,7 @@ export function PostCard({
           year: "numeric",
         })
       : undefined);
-  const excerpt = post.excerpt ?? post.summary ?? "";
+  const excerpt = post.excerpt ?? "";
 
   const containerPadding = variant === "featured" ? "p-8" : "p-6";
   const readingTime = post.readingTime ?? post.reading_time ?? null;


### PR DESCRIPTION
## Summary
- remove the `summary` column from Supabase post fetches in the write and post views
- generate excerpts/introductions from stored excerpts or plain-text content when needed
- update post card types and consumers to rely solely on excerpt-based summaries

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68df2d5352ac8320bc0d018456cfd3f7