### PR TITLE
Add document thumbnail previews to write dashboard

### DIFF
--- a/app/write/page.tsx
+++ b/app/write/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { JSONContent } from "@tiptap/core";
-import ThumbnailPreviewPage from "@/components/post/preview";
+import PostThumbnail from "@/components/post/PostThumbnail";
 
 import { createClient } from "@/lib/supabase/client";
 
@@ -19,6 +19,82 @@ type SupabasePost = {
   readonly excerpt?: string | null;
   readonly content_json?: JSONContent | null;
 };
+
+type ThumbnailPreview = {
+  readonly title: string;
+  readonly excerpt: string;
+  readonly slug: string;
+  readonly publishedAt: string | null;
+  readonly updatedAt: string | null;
+  readonly tags: readonly string[];
+  readonly thumbnail: {
+    readonly src: string;
+    readonly alt: string;
+    readonly width: number;
+    readonly height: number;
+    readonly priority?: boolean;
+  };
+};
+
+const THUMBNAIL_PREVIEWS: readonly ThumbnailPreview[] = [
+  {
+    title: "Ideas in flow",
+    excerpt: "A behind-the-scenes look at how I reshape fragments into a cohesive essay outline.",
+    slug: "ideas-in-flow",
+    publishedAt: "2024-05-26T08:30:00.000Z",
+    updatedAt: "2024-06-02T14:00:00.000Z",
+    tags: ["Process", "Craft", "Mindset"],
+    thumbnail: {
+      src: "/thumbnails/ideas-flow.svg",
+      alt: "Abstract wave lines over a lavender and blue gradient background",
+      width: 800,
+      height: 600,
+      priority: true,
+    },
+  },
+  {
+    title: "Morning pages ritual",
+    excerpt: "Capturing sunrise reflections and turning them into prompts worth revisiting.",
+    slug: "morning-pages-ritual",
+    publishedAt: "2024-05-18T06:45:00.000Z",
+    updatedAt: "2024-05-31T12:15:00.000Z",
+    tags: ["Habits", "Writing", "Wellness"],
+    thumbnail: {
+      src: "/thumbnails/morning-pages.svg",
+      alt: "Sunrise gradient with stylised mountain layers",
+      width: 800,
+      height: 600,
+    },
+  },
+  {
+    title: "Notebook atlas",
+    excerpt: "Mapping a research notebook so rabbit holes become navigable routes.",
+    slug: "notebook-atlas",
+    publishedAt: "2024-04-28T09:10:00.000Z",
+    updatedAt: "2024-05-12T10:00:00.000Z",
+    tags: ["Systems", "Research", "Tooling"],
+    thumbnail: {
+      src: "/thumbnails/notebook-atlas.svg",
+      alt: "Notebook grid with colourful connecting routes",
+      width: 800,
+      height: 600,
+    },
+  },
+  {
+    title: "Soundtrack notes",
+    excerpt: "Pairing playlists with essays to lock in tone, pacing, and emotion.",
+    slug: "soundtrack-notes",
+    publishedAt: "2024-04-08T19:20:00.000Z",
+    updatedAt: "2024-05-01T16:45:00.000Z",
+    tags: ["Inspiration", "Audio", "Mood"],
+    thumbnail: {
+      src: "/thumbnails/soundtrack-notes.svg",
+      alt: "Night sky gradient with neon waveform arcs",
+      width: 800,
+      height: 600,
+    },
+  },
+];
 
 type PostCard = {
   readonly id: string;
@@ -227,6 +303,31 @@ export default function WriteIndex() {
           {creating ? "Creating…" : "New draft"}
         </button>
       </div>
+
+      <section className="flex flex-col gap-6 rounded-3xl border border-[var(--editor-border)] bg-[var(--editor-surface)] p-6 shadow-[var(--editor-shadow)] sm:p-8">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-lg font-semibold text-[color:var(--editor-page-text)]">Document thumbnails</h2>
+          <p className="text-sm text-[color:var(--editor-muted)]">
+            Preview how a handful of posts could look on your published site. These examples use placeholder
+            artwork until real posts are created.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+          {THUMBNAIL_PREVIEWS.map((preview) => (
+            <PostThumbnail
+              key={preview.slug}
+              title={preview.title}
+              excerpt={preview.excerpt}
+              slug={preview.slug}
+              publishedAt={preview.publishedAt}
+              updatedAt={preview.updatedAt}
+              tags={preview.tags}
+              thumbnail={preview.thumbnail}
+              className="h-full"
+            />
+          ))}
+        </div>
+      </section>
 
       {error && (
         <div className="rounded-lg border border-[color:var(--editor-danger)] bg-[color:color-mix(in_srgb,var(--editor-danger)_10%,transparent)] px-4 py-3 text-sm text-[color:var(--editor-danger)]">

--- a/public/thumbnails/ideas-flow.svg
+++ b/public/thumbnails/ideas-flow.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f5f3ff" />
+      <stop offset="100%" stop-color="#e0f2fe" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#6366f1" />
+      <stop offset="100%" stop-color="#22d3ee" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#gradient)" />
+  <g fill="none" stroke="url(#accent)" stroke-width="8" stroke-linecap="round">
+    <path d="M120 420c120-160 260-160 380 0 120 160 200 160 260 40" opacity="0.5" />
+    <path d="M80 340c140-120 300-120 440 0 140 120 220 120 300 20" opacity="0.35" />
+    <path d="M160 500c100-140 220-140 320 0 100 140 180 140 240 30" opacity="0.65" />
+  </g>
+  <g fill="#0f172a">
+    <circle cx="220" cy="210" r="12" opacity="0.15" />
+    <circle cx="420" cy="160" r="18" opacity="0.2" />
+    <circle cx="610" cy="250" r="10" opacity="0.12" />
+  </g>
+  <text x="60" y="120" font-family="'Inter', sans-serif" font-size="42" font-weight="600" fill="#1e293b">Ideas in flow</text>
+  <text x="60" y="170" font-family="'Inter', sans-serif" font-size="22" fill="#334155">Turning scattered notes into a connected narrative.</text>
+</svg>

--- a/public/thumbnails/morning-pages.svg
+++ b/public/thumbnails/morning-pages.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="sunrise" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fef3c7" />
+      <stop offset="60%" stop-color="#fde68a" />
+      <stop offset="100%" stop-color="#fbcfe8" />
+    </linearGradient>
+    <linearGradient id="mountain" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#7c3aed" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#sunrise)" />
+  <path d="M0 430 Q160 320 320 420 T640 430 T800 420 V600 H0 Z" fill="url(#mountain)" opacity="0.65" />
+  <path d="M0 470 Q200 360 400 460 T800 470 V600 H0 Z" fill="#1e3a8a" opacity="0.35" />
+  <circle cx="620" cy="140" r="70" fill="#fde68a" opacity="0.85" />
+  <text x="60" y="120" font-family="'Inter', sans-serif" font-size="40" font-weight="600" fill="#1f2937">Morning pages</text>
+  <text x="60" y="165" font-family="'Inter', sans-serif" font-size="22" fill="#374151">Sunrise reflections before the inbox wakes up.</text>
+</svg>

--- a/public/thumbnails/notebook-atlas.svg
+++ b/public/thumbnails/notebook-atlas.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="paper" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#eef2ff" />
+      <stop offset="100%" stop-color="#e0f7fa" />
+    </linearGradient>
+    <linearGradient id="routes" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6" />
+      <stop offset="100%" stop-color="#14b8a6" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#paper)" />
+  <g stroke="#94a3b8" stroke-width="1" opacity="0.5">
+    <line x1="100" y1="80" x2="100" y2="520" />
+    <line x1="160" y1="80" x2="160" y2="520" />
+    <line x1="220" y1="80" x2="220" y2="520" />
+    <line x1="280" y1="80" x2="280" y2="520" />
+    <line x1="340" y1="80" x2="340" y2="520" />
+    <line x1="400" y1="80" x2="400" y2="520" />
+    <line x1="460" y1="80" x2="460" y2="520" />
+    <line x1="520" y1="80" x2="520" y2="520" />
+    <line x1="580" y1="80" x2="580" y2="520" />
+    <line x1="640" y1="80" x2="640" y2="520" />
+    <line x1="700" y1="80" x2="700" y2="520" />
+  </g>
+  <g fill="none" stroke="url(#routes)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M140 200 Q220 140 300 200 T460 220 T620 180" />
+    <path d="M160 320 Q260 260 360 320 T540 340 T680 300" opacity="0.7" />
+    <path d="M120 420 Q240 360 360 420 T540 440 T700 400" opacity="0.55" />
+  </g>
+  <g fill="#1e293b">
+    <circle cx="140" cy="200" r="12" />
+    <circle cx="300" cy="200" r="10" opacity="0.8" />
+    <circle cx="460" cy="220" r="9" opacity="0.65" />
+    <circle cx="620" cy="180" r="12" />
+  </g>
+  <text x="60" y="120" font-family="'Inter', sans-serif" font-size="40" font-weight="600" fill="#0f172a">Notebook atlas</text>
+  <text x="60" y="165" font-family="'Inter', sans-serif" font-size="22" fill="#1f2937">Mapping research trails and curiosities.</text>
+</svg>

--- a/public/thumbnails/soundtrack-notes.svg
+++ b/public/thumbnails/soundtrack-notes.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="midnight" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e293b" />
+    </linearGradient>
+    <linearGradient id="notes" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#a855f7" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#midnight)" />
+  <g fill="none" stroke="url(#notes)" stroke-width="6" stroke-linecap="round">
+    <path d="M80 420 C200 260 360 260 520 420 S760 580 840 420" opacity="0.8" />
+    <path d="M40 360 C180 220 360 220 520 360 S760 500 840 360" opacity="0.45" />
+    <path d="M120 480 C220 340 360 340 520 480 S760 620 840 480" opacity="0.6" />
+  </g>
+  <g>
+    <circle cx="220" cy="220" r="12" fill="#38bdf8" />
+    <circle cx="420" cy="160" r="14" fill="#a855f7" />
+    <circle cx="620" cy="240" r="10" fill="#f472b6" />
+  </g>
+  <text x="60" y="120" font-family="'Inter', sans-serif" font-size="38" font-weight="600" fill="#e0f2fe">Soundtrack notes</text>
+  <text x="60" y="165" font-family="'Inter', sans-serif" font-size="22" fill="#bae6fd">Scoring essays with moodboards and melodies.</text>
+</svg>


### PR DESCRIPTION
## Summary
- add placeholder thumbnail metadata and preview grid to the /write dashboard
- include four illustrative SVG assets to showcase fake posts

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68df3950539483209a82f0ac743cf539