### PR TITLE
Add thumbnail grid layout to write dashboard

### DIFF
--- a/app/write/page.tsx
+++ b/app/write/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { JSONContent } from "@tiptap/core";
-import PostThumbnail from "@/components/post/PostThumbnail";
+import ThumbnailGrid, { type ThumbnailGridItem } from "@/components/write/ThumbnailGrid";
 
 import { createClient } from "@/lib/supabase/client";
 
@@ -20,23 +20,7 @@ type SupabasePost = {
   readonly content_json?: JSONContent | null;
 };
 
-type ThumbnailPreview = {
-  readonly title: string;
-  readonly excerpt: string;
-  readonly slug: string;
-  readonly publishedAt: string | null;
-  readonly updatedAt: string | null;
-  readonly tags: readonly string[];
-  readonly thumbnail: {
-    readonly src: string;
-    readonly alt: string;
-    readonly width: number;
-    readonly height: number;
-    readonly priority?: boolean;
-  };
-};
-
-const THUMBNAIL_PREVIEWS: readonly ThumbnailPreview[] = [
+const THUMBNAIL_PREVIEWS: readonly ThumbnailGridItem[] = [
   {
     title: "Ideas in flow",
     excerpt: "A behind-the-scenes look at how I reshape fragments into a cohesive essay outline.",
@@ -312,21 +296,7 @@ export default function WriteIndex() {
             artwork until real posts are created.
           </p>
         </div>
-        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-          {THUMBNAIL_PREVIEWS.map((preview) => (
-            <PostThumbnail
-              key={preview.slug}
-              title={preview.title}
-              excerpt={preview.excerpt}
-              slug={preview.slug}
-              publishedAt={preview.publishedAt}
-              updatedAt={preview.updatedAt}
-              tags={preview.tags}
-              thumbnail={preview.thumbnail}
-              className="h-full"
-            />
-          ))}
-        </div>
+        <ThumbnailGrid items={THUMBNAIL_PREVIEWS} />
       </section>
 
       {error && (

--- a/components/post/PostThumbnail.tsx
+++ b/components/post/PostThumbnail.tsx
@@ -12,7 +12,7 @@ type ThumbnailImage = {
   readonly priority?: boolean;
 };
 
-type PostThumbnailProps = {
+export type PostThumbnailProps = {
   readonly title: string;
   readonly excerpt: string;
   readonly slug: string;
@@ -156,7 +156,7 @@ export function PostThumbnail({
 
   return (
     <article
-      className={`group relative flex h-full w-full basis-full flex-col overflow-hidden rounded-xl transition duration-200 sm:basis-1/2 xl:basis-1/3 ${className}`}
+      className={`group relative flex h-full w-full flex-col overflow-hidden rounded-xl transition duration-200 ${className}`}
     >
       <div className="relative h-56 w-full overflow-hidden sm:h-64">
         <Image

--- a/components/write/ThumbnailGrid.tsx
+++ b/components/write/ThumbnailGrid.tsx
@@ -1,0 +1,28 @@
+import PostThumbnail, { type PostThumbnailProps } from "@/components/post/PostThumbnail";
+
+export type ThumbnailGridItem = Omit<PostThumbnailProps, "className"> & {
+  readonly className?: string;
+};
+
+type ThumbnailGridProps = {
+  readonly items: readonly ThumbnailGridItem[];
+  readonly className?: string;
+};
+
+export function ThumbnailGrid({ items, className = "" }: ThumbnailGridProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`grid gap-6 [grid-template-columns:repeat(auto-fit,minmax(17rem,1fr))] ${className}`}
+    >
+      {items.map((item) => (
+        <PostThumbnail key={item.slug} {...item} />
+      ))}
+    </div>
+  );
+}
+
+export default ThumbnailGrid;


### PR DESCRIPTION
## Summary
- add a reusable `ThumbnailGrid` component that renders post thumbnails in an auto-fit layout
- update `PostThumbnail` to export its prop type and allow the grid to control sizing
- switch the `/write` dashboard to feed placeholder data into the new grid component

## Testing
- npm run build *(fails: cannot download Google Font in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68df3e63e8508320b866566dfc7d4cc0