### PR TITLE
Allow editor pages to use full width

### DIFF
--- a/components/editor/EditorShell.tsx
+++ b/components/editor/EditorShell.tsx
@@ -86,7 +86,7 @@ export default function EditorShell({ sidebar, children }: EditorShellProps) {
             <div className="flex-1 overflow-y-auto px-2 py-6 sm:px-3">{sidebar}</div>
           </aside>
           <main className="flex-1 overflow-y-auto px-10 py-10">
-            <div className="mx-auto w-full max-w-4xl space-y-8 pb-24">{children}</div>
+            <div className="space-y-8 pb-24">{children}</div>
           </main>
         </div>
       </div>

--- a/components/write/ThumbnailGrid.tsx
+++ b/components/write/ThumbnailGrid.tsx
@@ -15,9 +15,7 @@ export function ThumbnailGrid({ items, className = "" }: ThumbnailGridProps) {
   }
 
   return (
-    <div
-      className={` w-[100%] grid gap-6 [grid-template-columns:repeat(auto-fit,minmax(17rem,1fr))] ${className}`}
-    >
+    <div className={`grid w-full gap-6 [grid-template-columns:repeat(auto-fit,minmax(17rem,1fr))] ${className}`}>
       {items.map((item) => (
         <PostThumbnail key={item.slug} {...item} />
       ))}


### PR DESCRIPTION
## Summary
- remove the fixed max-width wrapper around editor content so pages like the write index can consume the full main column
- ensure the thumbnail grid component explicitly stretches to the full available width

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e01ab5eef8832096dafb3d86e63a5e