### PR TITLE
Adjust document thumbnail layout and styling

### DIFF
--- a/app/write/page.tsx
+++ b/app/write/page.tsx
@@ -288,7 +288,7 @@ export default function WriteIndex() {
         </button>
       </div>
 
-      <section className="w-full flex flex-col gap-6 rounded-3xl border border-[var(--editor-border)] bg-[var(--editor-surface)] p-6 shadow-[var(--editor-shadow)] sm:p-8">
+      <section className="w-full flex flex-col gap-6 rounded-3xl border border-[var(--editor-border)] p-6 shadow-[var(--editor-shadow)] sm:p-8">
         <div className="flex flex-col gap-1">
           <h2 className="text-lg font-semibold text-[color:var(--editor-page-text)]">Document thumbnails</h2>
           <p className="text-sm text-[color:var(--editor-muted)]">

--- a/components/post/PostThumbnail.tsx
+++ b/components/post/PostThumbnail.tsx
@@ -156,7 +156,7 @@ export function PostThumbnail({
 
   return (
     <article
-      className={`group relative flex h-full w-full flex-col overflow-hidden rounded-xl transition duration-200 ${className}`}
+      className={`group relative flex h-full w-full flex-col overflow-hidden border border-zinc-200 bg-white transition duration-200 dark:border-zinc-800 dark:bg-zinc-900 ${className}`}
     >
       <div className="relative h-56 w-full overflow-hidden sm:h-64">
         <Image

--- a/components/write/ThumbnailGrid.tsx
+++ b/components/write/ThumbnailGrid.tsx
@@ -15,7 +15,7 @@ export function ThumbnailGrid({ items, className = "" }: ThumbnailGridProps) {
   }
 
   return (
-    <div className={`grid w-full gap-6 [grid-template-columns:repeat(auto-fit,minmax(17rem,1fr))] ${className}`}>
+    <div className={`grid w-full gap-6 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 ${className}`}>
       {items.map((item) => (
         <PostThumbnail key={item.slug} {...item} />
       ))}


### PR DESCRIPTION
## Summary
- remove the surrounding section background so thumbnails sit directly on the editor surface
- update the thumbnail grid to use responsive column counts capped at three per row
- give each thumbnail card its own bordered surface with sharp corners

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e01e29d3f08320bf618bdd211c7c51