### PR TITLE
Tighten spacing for thumbnail previews

### DIFF
--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -71,9 +71,9 @@ export function PostCard({
     <article
       className={`group flex flex-col rounded-none ${cardBackground} transition-all duration-300 hover:-translate-y-1 hover:bg-[var(--accent)]/10 focus-within:bg-[var(--accent)]/10 ${hoverShadow}`}
     >
-      <div className="px-5 pt-5">
+      <div className="px-4 pb-3 pt-4">
         <div className="relative mx-auto w-full max-w-full overflow-hidden">
-          <div className="aspect-[21/9] w-full overflow-hidden">
+          <div className="aspect-[20/9] w-full overflow-hidden">
             {post.thumbnail?.src ? (
               <img
                 src={post.thumbnail.src}
@@ -98,8 +98,8 @@ export function PostCard({
         </div>
       </div>
 
-      <div className="flex flex-col gap-6 px-5 pb-6 pt-4">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+      <div className="flex flex-col gap-4 px-4 pb-5 pt-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-5">
           <div className="flex flex-1 flex-wrap items-baseline gap-x-3 gap-y-2">
             <TitleTag className={`${headingSize} ${titleColor} tracking-tight`}>
               <a

--- a/components/post/PostThumbnail.tsx
+++ b/components/post/PostThumbnail.tsx
@@ -158,7 +158,7 @@ export function PostThumbnail({
     <article
       className={`group relative flex h-full w-full flex-col overflow-hidden border border-zinc-300 bg-white transition-colors duration-200 hover:border-zinc-900/40 dark:border-zinc-700 dark:bg-zinc-950 dark:hover:border-zinc-100/50 ${className}`}
     >
-      <div className="relative flex h-40 w-full items-center justify-center bg-zinc-100/70 p-4 sm:h-48 sm:p-6 dark:bg-zinc-900/60">
+      <div className="relative flex h-36 w-full items-center justify-center bg-zinc-100/70 px-4 py-3 sm:h-44 sm:px-6 sm:py-4 dark:bg-zinc-900/60">
         <Image
           src={thumbnail.src}
           alt={thumbnail.alt}
@@ -170,8 +170,8 @@ export function PostThumbnail({
         />
       </div>
 
-      <div className="flex flex-1 flex-col gap-6 p-6 sm:p-8">
-        <header className="flex flex-col gap-3">
+      <div className="flex flex-1 flex-col gap-5 p-5 sm:p-6">
+        <header className="flex flex-col gap-2.5">
           {dateLabel && isoDate ? (
             <time
               dateTime={isoDate}


### PR DESCRIPTION
## Summary
- reduce padding around post card thumbnail headers so images fill their header area more fully
- tighten body spacing on post cards and generic post thumbnails to shorten the overall preview height
- adjust thumbnail aspect ratio and header heights for a more compact layout

## Testing
- npm run lint *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e425dbc9b88320864b2eb537b4a393